### PR TITLE
feat(text-input): add show/hide button when type is password

### DIFF
--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -27,7 +27,7 @@ export const Template = (args, { argTypes }) => ({
                       :disabled="disabled" :block="block"
                       :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
                       :loading="loading"
-                      :visible-password="visiblePassword"
+                      :password-visibility-mode="passwordVisibilityMode"
                       :type="type"
         >
             <template v-if="rightExtraSlot" #right-extra>
@@ -179,7 +179,7 @@ export const Template = (args, { argTypes }) => ({
         {{
             components: { PTextInput },
             template: `
-                <p-text-input v-model="value" type="password" visible-password />
+                <p-text-input v-model="value" type="password" password-visibility-mode />
             `,
             setup() {
                 const state = reactive({

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -173,10 +173,10 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-#### Visible Password
+#### Masking Mode
 
 <Canvas>
-    <Story name="Visible Password">
+    <Story name="Masking Mode">
         {{
             components: { PTextInput },
             template: `

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -27,7 +27,8 @@ export const Template = (args, { argTypes }) => ({
                       :disabled="disabled" :block="block"
                       :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
                       :loading="loading"
-                      :password-visibility-mode="passwordVisibilityMode"
+                      :masking-mode="maskingMode"
+                      :show-password="showPassword"
                       :type="type"
         >
             <template v-if="rightExtraSlot" #right-extra>
@@ -179,7 +180,7 @@ export const Template = (args, { argTypes }) => ({
         {{
             components: { PTextInput },
             template: `
-                <p-text-input v-model="value" type="password" password-visibility-mode />
+                <p-text-input v-model="value" type="password" masking-mode />
             `,
             setup() {
                 const state = reactive({

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -27,6 +27,8 @@ export const Template = (args, { argTypes }) => ({
                       :disabled="disabled" :block="block"
                       :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
                       :loading="loading"
+                      :visible-password="visiblePassword"
+                      :type="type"
         >
             <template v-if="rightExtraSlot" #right-extra>
                 <span v-html="rightExtraSlot"></span>
@@ -157,6 +159,27 @@ export const Template = (args, { argTypes }) => ({
             components: { PTextInput },
             template: `
                 <p-text-input v-model="value" type="password" />
+            `,
+            setup() {
+                const state = reactive({
+                    value: 'password'
+                })
+                return {
+                    ...toRefs(state)
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+#### Visible Password
+
+<Canvas>
+    <Story name="Visible Password">
+        {{
+            components: { PTextInput },
+            template: `
+                <p-text-input v-model="value" type="password" visible-password />
             `,
             setup() {
                 const state = reactive({

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -43,14 +43,14 @@
                     {{ value }}
                 </slot>
             </span>
-            <p-button v-if="(initialInputType === 'password') && passwordVisibilityMode"
+            <p-button v-if="($attrs.type === 'password') && maskingMode"
                       size="sm"
                       style-type="transparent"
                       font-weight="normal"
                       :disabled="disabled"
                       @click.stop.prevent="handleTogglePassword"
             >
-                {{ isPasswordVisible ? $t('COMPONENT.TEXT_INPUT.HIDE') : $t('COMPONENT.TEXT_INPUT.SHOW') }}
+                {{ !proxyShowPassword ? $t('COMPONENT.TEXT_INPUT.HIDE') : $t('COMPONENT.TEXT_INPUT.SHOW') }}
             </p-button>
             <p-i v-else
                  v-show="(isFocused || isInvalid)"
@@ -109,7 +109,7 @@ interface TextInputProps {
     disableHandler: boolean;
     exactMode: boolean;
     useAutoComplete: boolean;
-    passwordVisibilityMode: boolean;
+    maskingMode: boolean;
 }
 
 export default defineComponent<TextInputProps>({
@@ -192,9 +192,13 @@ export default defineComponent<TextInputProps>({
             type: Boolean,
             default: false,
         },
-        passwordVisibilityMode: {
+        maskingMode: {
             type: Boolean,
             default: false,
+        },
+        showPassword: {
+            type: Boolean,
+            default: true,
         },
     },
 
@@ -213,9 +217,14 @@ export default defineComponent<TextInputProps>({
             menuRef: null,
             targetRef: null,
             isFocused: false,
-            initialInputType: attrs.type,
-            inputType: useProxyValue('type', attrs, emit),
-            isPasswordVisible: computed(() => state.inputType !== 'password'),
+            proxyShowPassword: useProxyValue('showPassword', props, emit),
+            inputType: computed(() => {
+                if (props.maskingMode) {
+                    if (attrs.type === 'password') return state.proxyShowPassword ? 'password' : 'text';
+                    return attrs.type;
+                }
+                return attrs.type;
+            }),
             proxyValue: useProxyValue('value', props, emit),
             proxySelectedValue: useProxyValue('selected', props, emit),
             deleteTarget: undefined as string | undefined,
@@ -303,7 +312,7 @@ export default defineComponent<TextInputProps>({
         };
 
         const handleTogglePassword = () => {
-            state.inputType = state.isPasswordVisible ? 'password' : 'text';
+            state.proxyShowPassword = !state.proxyShowPassword;
         };
 
         const deleteSelectedTags = () => {
@@ -365,6 +374,9 @@ export default defineComponent<TextInputProps>({
         watch(() => props.menu, (menu) => {
             state.filteredMenu = menu;
             filterMenu(state.proxyValue);
+        });
+        watch(() => props.maskingMode, (maskingMode) => {
+            if (maskingMode) state.proxyShowPassword = true;
         });
 
         const init = () => {

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -18,7 +18,8 @@
                     {{ tag.label || tag.value }}
                 </p-tag>
                 <slot name="default" v-bind="{ value }">
-                    <input :type="inputType"
+                    <input v-bind="$attrs"
+                           :type="inputType"
                            :value="proxyValue"
                            :disabled="disabled"
                            :placeholder="placeholder"
@@ -28,7 +29,8 @@
                 </slot>
             </div>
             <slot v-else name="default" v-bind="{ value }">
-                <input :type="inputType"
+                <input v-bind="$attrs"
+                       :type="inputType"
                        :value="proxyValue"
                        :disabled="disabled"
                        :placeholder="placeholder"
@@ -41,12 +43,12 @@
                     {{ value }}
                 </slot>
             </span>
-            <p-button v-if="($attrs.type === 'password') && visiblePassword"
+            <p-button v-if="(initialInputType === 'password') && passwordVisibilityMode"
                       size="sm"
                       style-type="transparent"
                       font-weight="normal"
                       :disabled="disabled"
-                      @click="handleTogglePassword"
+                      @click.stop.prevent="handleTogglePassword"
             >
                 {{ isPasswordVisible ? $t('COMPONENT.TEXT_INPUT.HIDE') : $t('COMPONENT.TEXT_INPUT.SHOW') }}
             </p-button>
@@ -88,7 +90,7 @@ import PButton from '@/inputs/buttons/button/PButton.vue';
 import PContextMenu from '@/inputs/context-menu/PContextMenu.vue';
 import type { MenuItem } from '@/inputs/context-menu/type';
 import type { SearchDropdownMenuItem } from '@/inputs/dropdown/search-dropdown/type';
-import type { HTMLInputTypeAttribute, SelectedItem, TextInputHandler } from '@/inputs/input/type';
+import type { SelectedItem, TextInputHandler } from '@/inputs/input/type';
 
 
 interface TextInputProps {
@@ -107,7 +109,7 @@ interface TextInputProps {
     disableHandler: boolean;
     exactMode: boolean;
     useAutoComplete: boolean;
-    visiblePassword: boolean;
+    passwordVisibilityMode: boolean;
 }
 
 export default defineComponent<TextInputProps>({
@@ -190,7 +192,7 @@ export default defineComponent<TextInputProps>({
             type: Boolean,
             default: false,
         },
-        visiblePassword: {
+        passwordVisibilityMode: {
             type: Boolean,
             default: false,
         },
@@ -211,8 +213,9 @@ export default defineComponent<TextInputProps>({
             menuRef: null,
             targetRef: null,
             isFocused: false,
-            inputType: (attrs?.type) ?? 'text' as HTMLInputTypeAttribute,
-            isPasswordVisible: false,
+            initialInputType: attrs.type,
+            inputType: useProxyValue('type', attrs, emit),
+            isPasswordVisible: computed(() => state.inputType !== 'password'),
             proxyValue: useProxyValue('value', props, emit),
             proxySelectedValue: useProxyValue('selected', props, emit),
             deleteTarget: undefined as string | undefined,
@@ -300,8 +303,7 @@ export default defineComponent<TextInputProps>({
         };
 
         const handleTogglePassword = () => {
-            state.isPasswordVisible = !state.isPasswordVisible;
-            state.inputType = state.isPasswordVisible ? 'text' : 'password';
+            state.inputType = state.isPasswordVisible ? 'password' : 'text';
         };
 
         const deleteSelectedTags = () => {

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -247,10 +247,10 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
-        passwordVisibilityMode: {
-            name: 'passwordVisibilityMode',
+        maskingMode: {
+            name: 'maskingMode',
             type: { name: 'boolean' },
-            description: 'Use this prop when you want to control show/hide button of password input.',
+            description: 'Whether to use input masking or not.',
             defaultValue: false,
             table: {
                 type: {
@@ -259,6 +259,24 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 category: 'props',
                 defaultValue: {
                     summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        showPassword: {
+            name: 'showPassword',
+            type: { name: 'boolean' },
+            description: 'Whether to display password or not.',
+            defaultValue: true,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'true',
                 },
             },
             control: {

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -247,8 +247,8 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
-        visiblePassword: {
-            name: 'visiblePassword',
+        passwordVisibilityMode: {
+            name: 'passwordVisibilityMode',
             type: { name: 'boolean' },
             description: 'Use this prop when you want to control show/hide button of password input.',
             defaultValue: false,

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -247,6 +247,24 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
+        visiblePassword: {
+            name: 'visiblePassword',
+            type: { name: 'boolean' },
+            description: 'Use this prop when you want to control show/hide button of password input.',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
         // attrs
         inputAttrs: {
             name: 'all input attributes',
@@ -263,6 +281,23 @@ export const getTextInputArgTypes = (): ArgTypes => {
             },
             control: {
                 type: 'object',
+            },
+        },
+        type: {
+            name: 'type',
+            description: 'type of input tag (e.g. text, password, date ...)',
+            defaultValue: 'text',
+            table: {
+                type: {
+                    summary: null,
+                },
+                defaultValue: {
+                    summary: 'text',
+                },
+                category: 'attrs',
+            },
+            control: {
+                type: 'text',
             },
         },
         // model

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -301,23 +301,6 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'object',
             },
         },
-        type: {
-            name: 'type',
-            description: 'type of input tag (e.g. text, password, date ...)',
-            defaultValue: 'text',
-            table: {
-                type: {
-                    summary: null,
-                },
-                defaultValue: {
-                    summary: 'text',
-                },
-                category: 'attrs',
-            },
-            control: {
-                type: 'text',
-            },
-        },
         // model
         'v-model': {
             name: 'v-model',

--- a/src/inputs/input/type.ts
+++ b/src/inputs/input/type.ts
@@ -12,3 +12,7 @@ export interface SelectedItem {
 export interface TextInputHandler {
     (val: string, searchableItems: MenuItem[]): Promise<{results: MenuItem[]}>|{results: MenuItem[]}
 }
+
+// eslint-disable-next-line max-len
+type HTMLInputTypeAttribute = null | 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week';
+export type { HTMLInputTypeAttribute };

--- a/src/inputs/input/type.ts
+++ b/src/inputs/input/type.ts
@@ -12,7 +12,3 @@ export interface SelectedItem {
 export interface TextInputHandler {
     (val: string, searchableItems: MenuItem[]): Promise<{results: MenuItem[]}>|{results: MenuItem[]}
 }
-
-// eslint-disable-next-line max-len
-type HTMLInputTypeAttribute = null | 'button' | 'checkbox' | 'color' | 'date' | 'datetime-local' | 'email' | 'file' | 'hidden' | 'image' | 'month' | 'number' | 'password' | 'radio' | 'range' | 'reset' | 'search' | 'submit' | 'tel' | 'text' | 'time' | 'url' | 'week';
-export type { HTMLInputTypeAttribute };


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

https://user-images.githubusercontent.com/50662170/188403167-0aeba8af-d76f-4322-9b4b-3e72451c32b5.mov



add show/hide button when type is password

You just have to look at [this commit](https://github.com/cloudforet-io/mirinae/pull/3/commits/aa0729f29d99f816f47ba625c5184ceafaa71635)

- props.maskingMode
    If the value is true, the On/Off button is displayed.
- props.showPassword
    If type is password and maskingMode is true, determine whether to display the password as a value.


### Things to Talk About
