### PR TITLE
feat(markdown): add removeSpacing prop

### DIFF
--- a/src/data-display/markdown/PMarkdown.stories.mdx
+++ b/src/data-display/markdown/PMarkdown.stories.mdx
@@ -1,76 +1,21 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
 import PMarkdown from './PMarkdown.vue';
 import mock from './mock.ts';
+import {getMarkdownArgTypes} from "@/data-display/markdown/story-helper";
 
 <Meta title='Data Display/Markdown' parameters={{
     design: {
         type: 'figma',
         url: 'https://www.figma.com/file/wq4wSowBcADBuUrMEZLz6i/SpaceONE-Console-Design?node-id=5718%3A9288',
     },
-}} component={PMarkdown} argTypes={{
-    markdown: {
-        name: 'markdown',
-        type: {name: 'string'},
-        description: 'Markdown data',
-        defaultValue: mock.markdown,
-        table: {
-            type: {
-                summary: '`string` or `object`'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: ''
-            },
-        },
-        control: {
-            type: 'object'
-        }
-    },
-    data: {
-        name: 'data',
-        type: {name: 'object'},
-        description: 'Variable data to be rendered combined with markdown. Use the ejs.render function internally.',
-        defaultValue: mock.data,
-        table: {
-            type: {
-                summary: 'object'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: undefined
-            },
-        },
-        control: {
-            type: 'object',
-        }
-    },
-    language: {
-        name: 'language',
-        type: {name: 'string'},
-        description: 'Language for display markdown',
-        defaultValue: 'en',
-        table: {
-            type: {
-                summary: 'string'
-            },
-            category: 'props',
-            defaultValue: {
-                summary: 'en'
-            },
-        },
-        control: {
-            type: 'select',
-            options: ['en', 'ko']
-        }
-    },
-}}/>
+}} argTypes={getMarkdownArgTypes()}/>
 
 
 export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { PMarkdown },
     template: `
-        <p-markdown :markdown="markdown" :language="language" :data="data" >
+        <p-markdown :markdown="markdown" :language="language" :data="data" :inline="inline" >
         </p-markdown>
     `,
     setup() {

--- a/src/data-display/markdown/PMarkdown.vue
+++ b/src/data-display/markdown/PMarkdown.vue
@@ -1,10 +1,10 @@
 <template>
     <!-- eslint-disable -->
-    <div class="p-markdown" v-html="md" />
+    <div class="p-markdown" v-html="md" :class="{inline}" />
 </template>
 
 <script lang="ts">
-import { computed } from '@vue/composition-api';
+import { computed, defineComponent } from '@vue/composition-api';
 
 import DOMPurify from 'dompurify';
 import { render } from 'ejs';
@@ -28,7 +28,7 @@ marked.setOptions({
 });
 const DEFAULT_LANGUAGE = 'en';
 
-export default {
+export default defineComponent<MarkdownProps>({
     name: 'PMarkdown',
     props: {
         markdown: {
@@ -43,8 +43,12 @@ export default {
             type: String,
             default: 'en',
         },
+        inline: {
+            type: Boolean,
+            default: false,
+        },
     },
-    setup(props: MarkdownProps) {
+    setup(props) {
         const getI18nMd = (md: any) => get(md, props.language, md[DEFAULT_LANGUAGE] || Object.values(md)[0] || '');
         const md = computed(() => {
             let doc = typeof props.markdown === 'object' ? getI18nMd(props.markdown) : props.markdown || '';
@@ -58,16 +62,24 @@ export default {
             md,
         };
     },
-};
+});
 </script>
 
 <style lang="postcss">
 @import 'highlight.js/scss/atom-one-dark.scss';
 .p-markdown {
-    @apply w-full border-black text-gray-900;
-    padding-top: 1.5rem;
-    padding-bottom: 1rem;
-    padding-left: 1rem;
+    @apply text-gray-900;
+    &:not(.inline) {
+        @apply w-full border-black;
+        padding-top: 1.5rem;
+        padding-bottom: 1rem;
+        padding-left: 1rem;
+    }
+    &.inline {
+        p:last-child {
+            margin-bottom: 0;
+        }
+    }
     table {
         td,th {
             @apply px-4 py-2;

--- a/src/data-display/markdown/story-helper.ts
+++ b/src/data-display/markdown/story-helper.ts
@@ -1,0 +1,79 @@
+import type { ArgTypes } from '@storybook/addons';
+
+import mock from '@/data-display/markdown/mock';
+
+export const getMarkdownArgTypes = (): ArgTypes => ({
+    markdown: {
+        name: 'markdown',
+        type: { name: 'string' },
+        description: 'Markdown data',
+        defaultValue: mock.markdown,
+        table: {
+            type: {
+                summary: '`string` or `object`',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: '',
+            },
+        },
+        control: {
+            type: 'object',
+        },
+    },
+    data: {
+        name: 'data',
+        type: { name: 'object' },
+        description: 'Variable data to be rendered combined with markdown. Use the ejs.render function internally.',
+        defaultValue: mock.data,
+        table: {
+            type: {
+                summary: 'object',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: undefined,
+            },
+        },
+        control: {
+            type: 'object',
+        },
+    },
+    language: {
+        name: 'language',
+        type: { name: 'string' },
+        description: 'Language for display markdown',
+        defaultValue: 'en',
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'en',
+            },
+        },
+        control: {
+            type: 'select',
+            options: ['en', 'ko'],
+        },
+    },
+    inline: {
+        name: 'inline',
+        type: { name: 'boolean' },
+        description: 'Whether to make markdown root element\'s display style property inline and remove bottom margins or not.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+});

--- a/src/data-display/markdown/type.ts
+++ b/src/data-display/markdown/type.ts
@@ -2,4 +2,5 @@ export interface MarkdownProps {
     markdown: string | object;
     data?: object;
     language: string;
+    inline?: boolean;
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

- Add `inline` prop to make root element's display property 'inline'
  - when the `inline` prop is `true`,  last element's margin-bottom will be removed

### Things to Talk About

This PR is for PJsonSchemForm's `markdown` keyword spec.
![image](https://user-images.githubusercontent.com/26986739/188688376-ea3d8821-2f1a-401b-816c-4518275964cd.png)


