### PR TITLE
fix(data-loader): separate null, undefined data from boolean value & enable to use color token name as loaderBackdropColor prop

### DIFF
--- a/src/feedbacks/loading/data-loader/PDataLoader.stories.mdx
+++ b/src/feedbacks/loading/data-loader/PDataLoader.stories.mdx
@@ -35,6 +35,16 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
+## How it works with data prop?
+
+If the `data` prop is `undefined` or `null` , it is assumed that initial loading has not occurred yet. <br/>
+So the empty case screen is not visible. <br/>
+
+On the other hand, if the `data` prop is an empty `array` or an empty `object`, it is assumed that the data is empty and an empty case screen is displayed.<br/>
+
+When the type of `data` prop is `boolean`, if the value is `true`, data is considered to exist, and if `false`, data is considered empty.<br/>
+When you simply want to control whether an empty screen is shown or not, you can solve it by putting a `boolean` value in the `data` prop.<br/>
+
 ## Basic
 <Canvas>
     <Story name="Basic" >
@@ -68,6 +78,51 @@ export const Template = (args, { argTypes }) => ({
                     state.loading = false;
                 }
                 fetchData()
+                return {
+                    ...toRefs(state),
+                    fetchData
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Disable Empty Case
+<Canvas>
+    <Story name="Disable Empty Case" >
+        {{
+            components: { PDataLoader, PButton },
+            template: `
+<div class="w-full">
+    <p-button class="mb-2" style-type="primary" :outline="true" @click="fetchData">{{data.length ? 'Empty Data' : 'Load Data'}}</p-button>
+    <p-data-loader :loading="loading" :data="data" disable-empty-case
+        class="p-3 bg-gray-100 border border-gray-200"
+        style="width: 100%; height: 300px;"
+    >
+        <div v-for="(d, i) in data" :key="i" class="mb-3 leading-5">
+            {{d}}
+        </div>
+    </p-data-loader>
+</div>
+    `,
+            setup() {
+                const state = reactive({
+                    loading: false,
+                    data: range(15).map(() => faker.lorem.lines())
+                })
+                const fetchData = async () => {
+                    state.loading = true;
+                    state.data = await new Promise(resolve => {
+                        setTimeout(() => {
+                            if (state.data.length) resolve([])
+                            else resolve(range(15).map(() => faker.lorem.lines()))
+                        }, 1000)
+                    })
+                    state.loading = false;
+                }
                 return {
                     ...toRefs(state),
                     fetchData

--- a/src/feedbacks/loading/data-loader/PDataLoader.stories.mdx
+++ b/src/feedbacks/loading/data-loader/PDataLoader.stories.mdx
@@ -267,6 +267,10 @@ export const Template = (args, { argTypes }) => ({
 
 You can adjust the opacity of the loader backdrop through the `loaderBackdropOpacity` prop.<br/>
 You can also change the backdrop color through the `loaderBackdropColor` prop.<br/>
+<br/>
+
+For the `loaderBackdropColor` prop, you can give the name of the color token. <br/>
+e.g. `gray.900`
 
 <Canvas>
     <Story name="Loader Backdrop Opacity" >

--- a/src/feedbacks/loading/data-loader/PDataLoader.vue
+++ b/src/feedbacks/loading/data-loader/PDataLoader.vue
@@ -22,7 +22,7 @@
                 <div class="loader-backdrop"
                      :style="{
                          opacity: loaderBackdropOpacity,
-                         backgroundColor: loaderBackdropColor
+                         backgroundColor: refinedLoaderBackdropColor
                      }"
                 />
                 <div class="loader" :class="{[loaderType]: !$scopedSlots.loader}">
@@ -54,6 +54,7 @@ import { LOADER_TYPES } from '@/feedbacks/loading/data-loader/config';
 import PSkeleton from '@/feedbacks/loading/skeleton/PSkeleton.vue';
 import PLottie from '@/foundation/lottie/PLottie.vue';
 import { i18n } from '@/translations';
+import { getColor } from '@/util/helpers';
 
 interface Props {
     loading: boolean;
@@ -144,6 +145,7 @@ export default defineComponent<Props>({
             minLoading: props.loading,
             isTransitioning: false,
             showLoader: computed(() => (props.disableTransition ? isLoading.value : (isLoading.value || state.isTransitioning))),
+            refinedLoaderBackdropColor: computed(() => getColor(props.loaderBackdropColor)),
         });
 
         const registerLazyLoadingWatch = () => {

--- a/src/feedbacks/loading/data-loader/PDataLoader.vue
+++ b/src/feedbacks/loading/data-loader/PDataLoader.vue
@@ -132,9 +132,12 @@ export default defineComponent<Props>({
             dataLoadOccurred: false,
             showEmptyCase: computed(() => !props.disableEmptyCase && state.isEmpty),
             isEmpty: computed(() => {
-                if (!props.data) return false;
+                // if data is null or undefined, it regards as data is not loaded yet. so it's not empty case.
+                if (props.data === null || props.data === undefined) return false;
+
+                // in other cases, it checks if the data is empty.
                 if (Array.isArray(props.data)) return props.data.length === 0;
-                if (typeof props.data === 'boolean') return props.data;
+                if (typeof props.data === 'boolean') return !props.data;
                 return isEmpty(props.data);
             }),
             lazyLoading: props.loading,


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

![image](https://user-images.githubusercontent.com/26986739/191896183-d22dec9e-481a-4427-9bed-0c4f55cf8532.png)

Fixed things:
- If `data` prop is `undefined` or `null`, data is recognized as not empty. It regards as `undefined` or `null` as initial value and data load is not occurred.
- If `data` prop is boolean and the value is `true`, data is recognized as not empty, and if `false`, data is recognized as empty.
- Enable to use color token name as `loaderBackdropColor` prop.

![image](https://user-images.githubusercontent.com/26986739/191896212-0813f37f-b1ec-45f0-a9c5-8a8da8278a03.png)


### Things to Talk About
