### PR TITLE
feat(text-editor): add disableAutoReformat prop & refactor to use DataLoader for loading ux

### DIFF
--- a/src/inputs/text-editor/PTextEditor.stories.mdx
+++ b/src/inputs/text-editor/PTextEditor.stories.mdx
@@ -1,10 +1,14 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
 
-import PTextEditor from './PTextEditor.vue';
-
-import { getTextEditorArgTypes, sampleCode } from '@/inputs/text-editor/story-helper'; import {
+import {
     reactive, toRefs
 } from 'vue';
+
+import PTextEditor from './PTextEditor.vue';
+import PButton from "@/inputs/buttons/button/PButton";
+
+import { getTextEditorArgTypes, sampleCode } from '@/inputs/text-editor/story-helper';
+
 
 
 <Meta title='Inputs/Text Editor' parameters={{
@@ -20,7 +24,12 @@ export const Template = (args, { argTypes }) => ({
     components: { PTextEditor },
     template: `
     <div class="h-full w-full overflow p-8">
-        <p-text-editor :code="code" :folded="folded" />
+        <p-text-editor :code="code"
+            :folded="folded"
+            :read-only="readOnly" :loading="loading"
+            :highlight-lines="highlightLines"
+            :disable-auto-reformat="disableAutoReformat"
+        />
     </div>
     `,
 });
@@ -87,7 +96,6 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
-
 <Canvas>
     <Story name="Change Code">
         {{
@@ -116,6 +124,45 @@ export const Template = (args, { argTypes }) => ({
 
 <br/>
 <br/>
+
+## Auto Reformat on Code Change (string only)
+<br/>
+<br/>
+
+<Canvas>
+    <Story name="Auto Reformat on Code Change (string only)">
+        {{
+            components: { PTextEditor, PButton },
+            template: `
+    <div class="h-full w-full overflow p-8">
+        <p-text-editor :code="sampleCode" folded :disable-auto-reformat="disableAutoReformat" class="mb-4" />
+        <p-button style-type="primary" :outline="true" @click="handleChangeCode(false)">Change Code & Reformat (default)</p-button>
+        <p-button style-type="secondary" :outline="true" @click="handleChangeCode(true)">Change Code & Do not Reformat Automatically</p-button>
+       <p class="text-red-600 font-bold mt-4">This feature works only when the code prop's type is string</p>
+    </div>
+<!--<div>-->
+    `,
+            setup() {
+                const state = reactive({
+                    sampleCode,
+                    disableAutoReformat: false
+                });
+                const handleChangeCode = (disableAutoReformat) => {
+                    state.disableAutoReformat = disableAutoReformat;
+                    state.sampleCode = JSON.stringify({a: 3}, null, '');
+                };
+                return {
+                    ...toRefs(state),
+                    handleChangeCode,
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
 
 ## Playground
 

--- a/src/inputs/text-editor/PTextEditor.stories.mdx
+++ b/src/inputs/text-editor/PTextEditor.stories.mdx
@@ -8,6 +8,7 @@ import PTextEditor from './PTextEditor.vue';
 import PButton from "@/inputs/buttons/button/PButton";
 
 import { getTextEditorArgTypes, sampleCode } from '@/inputs/text-editor/story-helper';
+import { getJsonObject } from "@/inputs/text-editor/mock";
 
 
 
@@ -40,6 +41,10 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 
 
+## Basic
+<br/>
+<br/>
+
 <Canvas>
     <Story name="Basic">
         {{
@@ -64,6 +69,46 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
+## Loading
+<br/>
+<br/>
+
+<Canvas>
+    <Story name="Loading">
+        {{
+            components: { PTextEditor, PButton },
+            template: `
+    <div class="h-full w-full overflow p-8">
+        <p-text-editor :loading="loading" :code="sampleCode" folded />
+        <p-button class="mt-4" style-type="primary" @click="changeCode">Load Code!</p-button>
+    </div>
+    `,
+            setup() {
+                const state = reactive({
+                    sampleCode: undefined,
+                    loading: false
+                });
+                const changeCode = async () => {
+                    state.loading = true;
+                    state.sampleCode = await new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve(getJsonObject())
+                        }, 1500)
+                    })
+                    state.loading = false;
+                }
+                return {
+                    ...toRefs(state),
+                    changeCode
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
 ## Highlight Lines
 <br/>
 <br/>
@@ -79,7 +124,7 @@ export const Template = (args, { argTypes }) => ({
     `,
             setup() {
                 const state = reactive({
-                    sampleCode: sampleCode,
+                    sampleCode: getJsonObject(),
                 });
                 return {
                     ...toRefs(state),
@@ -108,10 +153,10 @@ export const Template = (args, { argTypes }) => ({
     `,
             setup() {
                 const state = reactive({
-                    sampleCode: sampleCode,
+                    sampleCode: getJsonObject(),
                 });
                 const handleChangeCode = () => {
-                    state.sampleCode = JSON.stringify({a: 3}, null, '');
+                    state.sampleCode = JSON.stringify(getJsonObject(), null, 2);
                 };
                 return {
                     ...toRefs(state),
@@ -149,7 +194,7 @@ export const Template = (args, { argTypes }) => ({
                 });
                 const handleChangeCode = (disableAutoReformat) => {
                     state.disableAutoReformat = disableAutoReformat;
-                    state.sampleCode = JSON.stringify({a: 3}, null, '');
+                    state.sampleCode = JSON.stringify(getJsonObject(), null, 0);
                 };
                 return {
                     ...toRefs(state),

--- a/src/inputs/text-editor/PTextEditor.vue
+++ b/src/inputs/text-editor/PTextEditor.vue
@@ -1,20 +1,13 @@
 <template>
     <div class="p-text-editor">
-        <transition name="fade-in">
-            <div v-if="loading" class="loader w-full h-full">
-                <slot name="loader" :loading="loading">
-                    <p-lottie name="thin-spinner"
-                              auto
-                              :size="2.5"
-                              class="flex items-center justify-center"
-                    />
-                </slot>
-            </div>
-        </transition>
-        <textarea ref="textareaRef"
-                  name="codemirror"
-                  placeholder=""
-        />
+        <p-data-loader :data="true" :loading="loading" disable-empty-case
+                       show-data-from-scratch loader-backdrop-color="gray.900"
+        >
+            <textarea ref="textareaRef"
+                      name="codemirror"
+                      placeholder=""
+            />
+        </p-data-loader>
     </div>
 </template>
 
@@ -41,7 +34,7 @@ import type { EditorConfiguration } from 'codemirror';
 import CodeMirror from 'codemirror';
 import { forEach } from 'lodash';
 
-import PLottie from '@/foundation/lottie/PLottie.vue';
+import PDataLoader from '@/feedbacks/loading/data-loader/PDataLoader.vue';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('codemirror/mode/javascript/javascript');
@@ -68,7 +61,7 @@ interface Props {
 
 export default defineComponent<Props>({
     name: 'PTextEditor',
-    components: { PLottie },
+    components: { PDataLoader },
     props: {
         code: {
             type: [Array, Object, String, Number] as PropType<any>,
@@ -123,12 +116,14 @@ export default defineComponent<Props>({
 
         const refineCode = (code: any): string => {
             if (typeof code === 'string') {
-                if (code.startsWith('{') || code.startsWith('[')) {
+                const trimmedCode = code.trim();
+                if (trimmedCode.startsWith('{') || trimmedCode.startsWith('[')) {
                     try {
                         // Object encased in String
                         // "{height: 182}"
-                        const obj = JSON.parse(code);
+                        const obj = JSON.parse(trimmedCode);
                         if (props.disableAutoReformat) return code;
+
                         return JSON.stringify(obj, undefined, 4);
                     } catch {
                         // Looks like Object encased in String, BUT Pure String
@@ -235,43 +230,43 @@ export default defineComponent<Props>({
 @import 'codemirror/addon/lint/lint.css';
 @import 'codemirror/addon/fold/foldgutter.css';
 .p-text-editor {
-    position: relative;
     height: 100%;
     min-height: 5rem;
-    > textarea {
-        display: none;
-    }
-    > .CodeMirror {
-        .CodeMirror-addedline {
-            width: 1rem;
-        }
-        .CodeMirror-gutters {
-            border-right: 0.03rem solid rgba(109, 138, 136, 0.5);
-        }
-        .CodeMirror-activeline-gutter, .CodeMirror-activeline-background {
-            background-color: rgba(255, 255, 222, 0.3);
-        }
-        font-family: Inconsolata, monospace;
-        line-height: 1.5;
-        height: fit-content;
-        padding: 1rem;
+    > .p-data-loader {
         min-height: inherit;
-        > .CodeMirror-scroll {
+        > .data-loader-container {
             min-height: inherit;
+            > .data-wrapper {
+                min-height: inherit;
+                > textarea {
+                    display: none;
+                }
+
+                > .CodeMirror {
+                    .CodeMirror-addedline {
+                        width: 1rem;
+                    }
+
+                    .CodeMirror-gutters {
+                        border-right: 0.03rem solid rgba(109, 138, 136, 0.5);
+                    }
+
+                    .CodeMirror-activeline-gutter, .CodeMirror-activeline-background {
+                        background-color: rgba(255, 255, 222, 0.3);
+                    }
+
+                    font-family: Inconsolata, monospace;
+                    line-height: 1.5;
+                    height: fit-content;
+                    padding: 1rem;
+                    min-height: inherit;
+
+                    > .CodeMirror-scroll {
+                        min-height: inherit;
+                    }
+                }
+            }
         }
-    }
-    .loader {
-        position: absolute;
-        padding-top: 2rem;
-    }
-    .fade-in-leave-active, .fade-in-enter-active {
-        transition: opacity 0.5s;
-    }
-    .fade-in-leave-to, .fade-in-enter {
-        opacity: 0;
-    }
-    .fade-in-enter-to, .fade-in-leave {
-        opacity: 1;
     }
 }
 </style>

--- a/src/inputs/text-editor/mock.ts
+++ b/src/inputs/text-editor/mock.ts
@@ -1,0 +1,3 @@
+import { faker } from '@faker-js/faker';
+
+export const getJsonObject = () => JSON.parse(faker.datatype.json());

--- a/src/inputs/text-editor/story-helper.ts
+++ b/src/inputs/text-editor/story-helper.ts
@@ -39,7 +39,7 @@ export const getTextEditorArgTypes = (): ArgTypes => ({
             },
         },
         control: {
-            type: 'text',
+            type: 'object',
         },
     },
     options: {
@@ -143,6 +143,24 @@ export const getTextEditorArgTypes = (): ArgTypes => ({
         },
         control: {
             type: 'object',
+        },
+    },
+    disableAutoReformat: {
+        name: 'disableAutoReformat',
+        type: { name: 'boolean' },
+        description: 'Whether to disable auto reformatting of code on code change or not. It works only when the code prop\'s type is `string`.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
         },
     },
     /* slots */


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [x] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

- Add `disableAutoReformat` prop

![image](https://user-images.githubusercontent.com/26986739/191896825-27843fdf-bc71-4df7-ad9e-fd09c7b6ec0b.png)


https://user-images.githubusercontent.com/26986739/191896917-66246dc8-5ed5-43ab-9e67-16d9748441a0.mov



- Use `DataLoader` component for loading UX

https://user-images.githubusercontent.com/26986739/191893527-4adffc8a-9460-4723-989a-f784007983f2.mov



### Things to Talk About
