### PR TITLE
feat(json-schema-form): add order keyword

### DIFF
--- a/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
@@ -69,8 +69,9 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 |markdown keyword|custom|[Markdown](?path=/docs/data-display-markdown--string-markdown)|
 |generate_id format|custom|GenerateIdFormat (Internal Component)|
 |json format|custom|[Text Editor](?path=/docs/inputs-text-editor--basic)|
+|enum keyword(supports string type only)|custom|[Select Dropdown](?path=/docs/inputs-dropdown-select-dropdown--basic)|
+|order keyword(order of properties. string[])|custom|-|
 |array type(NOT supported yet)|custom|[Text Input](?path=/docs/inputs-input--basic)|
-|string type & enum keyword(NOT supported yet)|custom|[Select Dropdown](?path=/docs/inputs-dropdown-select-dropdown--basic)|
 |array type & enum keyword(NOT supported yet)|custom|[Search Dropdown](?path=/docs/inputs-dropdown-search-dropdown--basic)|
 
 

--- a/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.vue
+++ b/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.vue
@@ -123,6 +123,7 @@ export default defineComponent<JsonSchemaFormProps>({
         const state = reactive({
             schemaProperties: computed<InnerJsonSchema[]>(() => {
                 const properties: object|undefined = props.schema?.properties;
+                const order: string[] = props.schema?.order ?? [];
                 if (properties && !isEmpty(properties)) {
                     return Object.entries(properties).map(([k, schemaProperty]) => {
                         const refined: InnerJsonSchema = {
@@ -134,6 +135,23 @@ export default defineComponent<JsonSchemaFormProps>({
                             menuItems: getMenuItemsBySchemaProperty(schemaProperty),
                         };
                         return refined;
+                    }).sort((a, b) => {
+                        const orderA = order.findIndex(id => id === a.id);
+                        const orderB = order.findIndex(id => id === b.id);
+
+                        // If both do not have order information, they are sorted based on title or id(=property name).
+                        if (orderA === -1 && orderB === -1) {
+                            const textA = a.title ?? a.id;
+                            const textB = b.title ?? b.id;
+                            return textA.localeCompare(textB);
+                        }
+
+                        // If only one of them does not have order information, the item without order information is placed at the back.
+                        if (orderA === -1) return 1;
+                        if (orderB === -1) return -1;
+
+                        // If both have order information, sort based on the order information.
+                        return orderA - orderB;
                     });
                 }
                 return [];

--- a/src/inputs/forms/new-json-schema-form/custom-schema.ts
+++ b/src/inputs/forms/new-json-schema-form/custom-schema.ts
@@ -26,4 +26,8 @@ export const addCustomKeywords = (ajv: Ajv): void => {
         keyword: 'markdown',
         schemaType: 'string',
     });
+    ajv.addKeyword({
+        keyword: 'order',
+        schemaType: 'array',
+    });
 };

--- a/src/inputs/forms/new-json-schema-form/mock.ts
+++ b/src/inputs/forms/new-json-schema-form/mock.ts
@@ -3,17 +3,6 @@ import { faker } from '@faker-js/faker';
 export const getDefaultSchema = () => ({
     type: 'object',
     properties: {
-        user_id: {
-            title: 'ID',
-            format: 'generate_id',
-            markdown: '[How to generate ID?](https://www.google.com)',
-        },
-        password: {
-            title: 'Password',
-            minLength: 8,
-            format: 'password',
-            default: '12345678',
-        },
         user_name: {
             minLength: 4,
             title: 'Name',
@@ -31,6 +20,17 @@ export const getDefaultSchema = () => ({
             examples: [
                 'Genie',
             ],
+        },
+        user_id: {
+            title: 'ID',
+            format: 'generate_id',
+            markdown: '[How to generate ID?](https://www.google.com)',
+        },
+        password: {
+            title: 'Password',
+            minLength: 8,
+            format: 'password',
+            default: '12345678',
         },
         country_code: {
             examples: ['82'],
@@ -84,6 +84,7 @@ export const getDefaultSchema = () => ({
 
     },
     required: ['user_id', 'password', 'user_name', 'age', 'homepage', 'phone', 'additional'],
+    order: ['user_id', 'password', 'user_name', 'user_nickname', 'country_code', 'age', 'phone', 'homepage', 'additional'],
 });
 
 export const getDefaultFormData = () => ({

--- a/src/inputs/forms/new-json-schema-form/type.ts
+++ b/src/inputs/forms/new-json-schema-form/type.ts
@@ -17,9 +17,11 @@ export type ValidationMode = typeof VALIDATION_MODES[number]
 export type InnerJsonSchema = JsonSchema & {
     id: string;
     componentName: ComponentName;
+    title?: string;
     inputType?: TextInputType;
     inputPlaceholder?: string;
     menuItems?: SelectDropdownMenu[];
+    order?: string[];
 }
 
 export interface JsonSchemaFormProps {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [ ] Tested with console

### Description

#### Add order keyword to ensure the order of properties

e.g. 

```typescript
{ 
   type: 'object',
   properties: { name: { type: 'string' }, age: { type: 'number'}, id: { type: 'string' } },
   required: ['name', 'id'],
   order: ['id', 'name', 'age']
}
```

##### Rule:
1. If both do not have order information, they are sorted based on title or id(=property name).
2. If only one of them does not have order information, the item without order information is placed at the back.
3. If both have order information, sort based on the order information.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/26986739/192409885-ddb706d0-affa-4c74-b105-c406f5b96dc0.png">

<img width="986" alt="image" src="https://user-images.githubusercontent.com/26986739/192409856-7e8f4af6-f6a7-4f2d-a394-209960b5d7ac.png">


### Things to Talk About
