### PR TITLE
feat(p-definition): add Object & Array type data spec

### DIFF
--- a/src/data-display/tables/definition-table/definition/PDefinition.vue
+++ b/src/data-display/tables/definition-table/definition/PDefinition.vue
@@ -8,10 +8,10 @@
         <td class="value-wrapper" :class="{'auto-width': autoKeyWidth}">
             <span class="value">
                 <slot v-if="disableCopy" name="default" v-bind="{name, label, data, value: displayData}">
-                    <template v-if="dataConstructorType === Object">
+                    <template v-if="dataType === 'object'">
                         <p-dict-list class="p-dict-list" :dict="displayData" />
                     </template>
-                    <template v-else-if="dataConstructorType === Array">
+                    <template v-else-if="dataType === 'array'">
                         <p-text-list :items="displayData" />
                     </template>
                     <template v-else>
@@ -24,10 +24,10 @@
                                auto-hide-icon
                 >
                     <slot name="default" v-bind="{name, label, data, value: displayData}">
-                        <template v-if="dataConstructorType === Object">
+                        <template v-if="dataType === 'object'">
                             <p-dict-list class="p-dict-list" :dict="displayData" />
                         </template>
-                        <template v-else-if="dataConstructorType === Array">
+                        <template v-else-if="dataType === 'array'">
                             <p-text-list :items="displayData" />
                         </template>
                         <template v-else>
@@ -97,7 +97,10 @@ export default defineComponent<DefinitionProps>({
     setup(props) {
         const state = reactive({
             displayData: computed(() => (props.formatter ? props.formatter(props.data, props) : props.data)),
-            dataConstructorType: computed(() => props.data.constructor),
+            dataType: computed(() => {
+                if (Array.isArray(props.data)) return 'array';
+                return typeof props.data;
+            }),
         });
 
         return {

--- a/src/data-display/tables/definition-table/definition/PDefinition.vue
+++ b/src/data-display/tables/definition-table/definition/PDefinition.vue
@@ -8,7 +8,15 @@
         <td class="value-wrapper" :class="{'auto-width': autoKeyWidth}">
             <span class="value">
                 <slot v-if="disableCopy" name="default" v-bind="{name, label, data, value: displayData}">
-                    {{ displayData }}
+                    <template v-if="dataConstructorType === Object">
+                        <p-dict-list class="p-dict-list" :dict="displayData" />
+                    </template>
+                    <template v-else-if="dataConstructorType === Array">
+                        <p-text-list :items="displayData" />
+                    </template>
+                    <template v-else>
+                        {{ displayData }}
+                    </template>
                 </slot>
                 <p-copy-button v-else
                                width="0.8rem" height="0.8rem"
@@ -16,7 +24,15 @@
                                auto-hide-icon
                 >
                     <slot name="default" v-bind="{name, label, data, value: displayData}">
-                        {{ displayData }}
+                        <template v-if="dataConstructorType === Object">
+                            <p-dict-list class="p-dict-list" :dict="displayData" />
+                        </template>
+                        <template v-else-if="dataConstructorType === Array">
+                            <p-text-list :items="displayData" />
+                        </template>
+                        <template v-else>
+                            {{ displayData }}
+                        </template>
                     </slot>
                 </p-copy-button>
             </span>
@@ -32,12 +48,14 @@ import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
 
+import PDictList from '@/data-display/dynamic/dynamic-field/templates/list/dict-list/PDictList.vue';
 import type { DefinitionProps } from '@/data-display/tables/definition-table/definition/type';
 import PCopyButton from '@/inputs/buttons/copy-button/PCopyButton.vue';
+import PTextList from '@/others/console/text-list/PTextList.vue';
 
 export default defineComponent<DefinitionProps>({
     name: 'PDefinition',
-    components: { PCopyButton },
+    components: { PTextList, PCopyButton, PDictList },
     props: {
         name: {
             type: String,
@@ -76,11 +94,11 @@ export default defineComponent<DefinitionProps>({
             default: false,
         },
     },
-    setup(props: DefinitionProps) {
+    setup(props) {
         const state = reactive({
             displayData: computed(() => (props.formatter ? props.formatter(props.data, props) : props.data)),
+            dataConstructorType: computed(() => props.data.constructor),
         });
-
 
         return {
             ...toRefs(state),
@@ -152,6 +170,10 @@ export default defineComponent<DefinitionProps>({
             width: 100%;
             max-width: 100%;
         }
+    }
+
+    .p-dict-list {
+        display: inline-grid;
     }
 }
 </style>

--- a/src/data-display/tables/definition-table/definition/story-helper.ts
+++ b/src/data-display/tables/definition-table/definition/story-helper.ts
@@ -117,9 +117,6 @@ export const getDefinitionArgTypes = (): ArgTypes => ({
                 summary: 'undefined',
             },
         },
-        control: {
-            type: 'text',
-        },
     },
     copyValueFormatter: {
         name: 'copyValueFormatter',
@@ -138,9 +135,9 @@ export const getDefinitionArgTypes = (): ArgTypes => ({
     },
     autoKeyWidth: {
         name: 'autoKeyWidth',
-        type: { name: 'string' },
+        type: { name: 'boolean' },
         description: 'Make key width auto',
-        defaultValue: undefined,
+        defaultValue: false,
         table: {
             type: {
                 summary: 'string',
@@ -149,9 +146,6 @@ export const getDefinitionArgTypes = (): ArgTypes => ({
             defaultValue: {
                 summary: 'undefined',
             },
-        },
-        control: {
-            type: 'boolean',
         },
     },
     /* slots */


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [ ] Tested with console

### Description
- add `dataConstructorType` state for checking data type.
- if `dataConstructorType` is `Object`, apply to `p-dict-list`.
- if `dataConstructorType` is `Array`, apply to `p-text-list`.

![image](https://user-images.githubusercontent.com/83635051/192418019-5cb73e1a-8d79-4c1a-adc9-c2a072fa72d2.png)


### Things to Talk About
- is it appropriate to use constructor type?
- for applying data type, which way would be better?
  a. add `props` for add data type in parent component
  b. current way
