### PR TITLE
fix(p-button-modal): add `hideFooterConfirmButton` props

### DIFF
--- a/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
+++ b/src/feedbacks/modals/button-modal/PButtonModal.stories.mdx
@@ -29,6 +29,7 @@ export const Template = (args, {argTypes} ) => ({
                                 :hide-footer="hideFooter"
                                 :hide-header-close-button="hideHeaderCloseButton"
                                 :hide-footer-close-button="hideFooterCloseButton"
+                                :hide-footer-confirm-button="hideFooterConfirmButton"
                                 :footer-reset-button-visible="footerResetButtonVisible"
                                 :loading="loading"
                                 :disabled="disabled"
@@ -132,6 +133,7 @@ export const Template = (args, {argTypes} ) => ({
 
 
 ## Playground
+
 <Canvas>
     <Story name="playground">
         {Template.bind({})}

--- a/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -61,6 +61,7 @@
                                 </slot>
                             </p-button>
                             <p-button
+                                v-if="!hideFooterConfirmButton"
                                 class="modal-button confirm-button"
                                 :class="{'no-cancel-button': hideFooterCloseButton}"
                                 :style-type="themeColor"
@@ -152,6 +153,10 @@ export default defineComponent<ButtonModalProps>({
             default: false,
         },
         hideFooterCloseButton: {
+            type: Boolean,
+            default: false,
+        },
+        hideFooterConfirmButton: {
             type: Boolean,
             default: false,
         },

--- a/src/feedbacks/modals/button-modal/story-helper.ts
+++ b/src/feedbacks/modals/button-modal/story-helper.ts
@@ -204,6 +204,24 @@ export const getButtonModalArgTypes = (): ArgTypes => ({
             type: 'boolean',
         },
     },
+    hideFooterConfirmButton: {
+        name: 'hideFooterConfirmButton',
+        type: { name: 'boolean' },
+        description: 'Whether to hide footer confirm button or not.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: false,
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
     loading: {
         name: 'loading',
         type: { name: 'boolean' },

--- a/src/feedbacks/modals/button-modal/type.ts
+++ b/src/feedbacks/modals/button-modal/type.ts
@@ -35,6 +35,7 @@ export interface ButtonModalProps {
 
     hideHeaderCloseButton: boolean;
     hideFooterCloseButton: boolean;
+    hideFooterConfirmButton: boolean;
     footerResetButtonVisible: boolean;
 
     loading: boolean;


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description
Add `hideFooterConfirmButton` props to hide confirm button
![스크린샷 2022-09-29 오후 3 37 05](https://user-images.githubusercontent.com/18563857/192957129-b5b6380b-3ad9-401c-aecb-3e6d2bd1e3be.png)