### PR TITLE
feat(json-schema-form): add json keyword(remove json format) which works for object type

### DIFF
--- a/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
@@ -68,7 +68,7 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 |password format|ajv-format|[Text Input](?path=/docs/inputs-input--basic)|
 |markdown keyword|custom|[Markdown](?path=/docs/data-display-markdown--string-markdown)|
 |generate_id format|custom|GenerateIdFormat (Internal Component)|
-|json keyword(json input mode)|custom|[Text Editor](?path=/docs/inputs-text-editor--basic)|
+|json keyword(json input mode. works only with object type)|custom|[Text Editor](?path=/docs/inputs-text-editor--basic)|
 |enum keyword(supports string type only)|custom|[Select Dropdown](?path=/docs/inputs-dropdown-select-dropdown--basic)|
 |order keyword(order of properties. string[])|custom|-|
 |disabled keyword(disabled status of input form. string[])|custom|-|

--- a/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/src/inputs/forms/new-json-schema-form/PJsonSchemaForm.stories.mdx
@@ -12,7 +12,7 @@ import {
      getJsonSchemaFormArgTypes,
 } from '@/inputs/forms/new-json-schema-form/story-helper';
 import {
-    getDefaultFormData, getDefaultSchema
+    getDefaultFormData, getDefaultSchema, getJsonInputSchema
 } from "@/inputs/forms/new-json-schema-form/mock";
 import {supportLanguages} from "@/translations";
 import {
@@ -68,7 +68,7 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 |password format|ajv-format|[Text Input](?path=/docs/inputs-input--basic)|
 |markdown keyword|custom|[Markdown](?path=/docs/data-display-markdown--string-markdown)|
 |generate_id format|custom|GenerateIdFormat (Internal Component)|
-|json format|custom|[Text Editor](?path=/docs/inputs-text-editor--basic)|
+|json keyword(json input mode)|custom|[Text Editor](?path=/docs/inputs-text-editor--basic)|
 |enum keyword(supports string type only)|custom|[Select Dropdown](?path=/docs/inputs-dropdown-select-dropdown--basic)|
 |order keyword(order of properties. string[])|custom|-|
 |disabled keyword(disabled status of input form. string[])|custom|-|
@@ -270,6 +270,53 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
                     formData: {},
                     validationModes: VALIDATION_MODES.map(d => ({name: d, label: d})),
                     validationMode: VALIDATION_MODES[0]
+                })
+                return {
+                    ...toRefs(state),
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Json Input Mode
+
+<Canvas>
+    <Story name="Json Input Mode" >
+        {{
+            components: { PJsonSchemaForm, PTextEditor, PPanelTop },
+            i18n,
+            template: `
+<div class="grid gap-4 grid-cols-12">
+    <div class="col-span-6 bg-blue-100 p-4">
+        <p-panel-top>Json Schema Form</p-panel-top>
+        <p-json-schema-form :schema="schema"
+                            :form-data.sync="formData"
+                            :language="$i18n.locale"
+        />
+    </div>
+    <div class="col-span-6 bg-coral-100 p-4">
+        <p-panel-top>Schema</p-panel-top>
+        <p-text-editor :code="JSON.stringify(schema, null, 2)"
+                       mode="readOnly"
+                       folded
+                       style="height: auto"
+        />
+        <p-panel-top>Form Data</p-panel-top>
+        <p-text-editor :code="JSON.stringify(formData, null, 2)"
+                       mode="readOnly"
+                       style="height: auto"
+        />
+    </div>
+</div>
+`,
+            setup(props) {
+                const state = reactive({
+                    schema: getJsonInputSchema(),
+                    formData: {},
                 })
                 return {
                     ...toRefs(state),

--- a/src/inputs/forms/new-json-schema-form/composables/validation.ts
+++ b/src/inputs/forms/new-json-schema-form/composables/validation.ts
@@ -10,9 +10,14 @@ import { isEmpty } from 'lodash';
 
 import type { JsonSchemaFormProps, InnerJsonSchema } from '@/inputs/forms/new-json-schema-form/type';
 
+const getErrorMessage = ({ instancePath, message, params }: ErrorObject) => {
+    const dataKey = instancePath.slice(1).replace('/', '.');
+    return `${dataKey ? `${dataKey}: ` : ''}${message}${params.allowedValues ? `: ${params.allowedValues.join(', ')}` : ''}`;
+};
+
 export const useValidation = (props: JsonSchemaFormProps, { ajv, formData, localize }: {
     ajv: Ajv,
-    formData: Ref<object>;
+    formData: Ref<object|undefined>;
     localize: Ref<Localize|null>;
 }) => {
     const state = reactive({
@@ -23,8 +28,8 @@ export const useValidation = (props: JsonSchemaFormProps, { ajv, formData, local
             return null;
         }),
         validatorErrors: null as ErrorObject[]|null,
-        invalidMessages: computed<Record<string, string|undefined>>(() => {
-            const errorObj = {};
+        invalidMessagesMap: computed<Record<string, string[]>>(() => { // invalid message array map for form input case
+            const errorObj: Record<string, string[]> = {};
 
             if (state.validatorErrors) {
                 if (localize.value) {
@@ -32,31 +37,52 @@ export const useValidation = (props: JsonSchemaFormProps, { ajv, formData, local
                 }
 
                 state.validatorErrors.forEach((error) => {
-                    if (!error.instancePath) {
+                    if (!error.instancePath && props.isRoot) {
                         /*
                          when the formData value is undefined, instancePath is empty string.
                          get property names that have 'required' error from error.params' value.
                          */
                         Object.values(error.params).forEach((property) => {
-                            errorObj[property] = error.message;
+                            if (errorObj[property as string]) {
+                                errorObj[property as string].push(getErrorMessage(error));
+                            } else {
+                                errorObj[property as string] = [getErrorMessage(error)];
+                            }
                         });
                     } else {
-                        const dataKey = error.instancePath.slice(1);
+                        const dataKey = error.instancePath.split('/')?.[1];
                         // 'required' error has high priority
-                        if (!errorObj[dataKey]) errorObj[dataKey] = error.message;
+                        if (errorObj[dataKey]) {
+                            errorObj[dataKey].push(getErrorMessage(error));
+                        } else {
+                            errorObj[dataKey] = [getErrorMessage(error)];
+                        }
                     }
                 });
             }
             return errorObj;
         }),
-        inputOccurred: {} as Record<string, boolean|undefined>,
+        inputOccurredMap: {} as Record<string, boolean|undefined>,
+        invalidMessages: computed<string[]>(() => { // invalid message array for json input case
+            let errorTexts: string[] = [];
+            if (state.jsonInputParsingError) errorTexts.push(state.jsonInputParsingError.message);
+            if (!state.validatorErrors) return errorTexts;
+
+            if (localize.value) {
+                localize.value(state.validatorErrors);
+            }
+            errorTexts = errorTexts.concat(state.validatorErrors.map(error => getErrorMessage(error)));
+            return errorTexts;
+        }),
+        jsonInputOccurred: false,
+        jsonInputParsingError: null as Error|null,
     });
 
     const validateFormData = (): boolean => {
         const validator = state.validator;
         if (!validator) return false;
 
-        const valid = validator(formData.value);
+        const valid = validator(formData.value ?? {});
 
         if (!valid && validator.errors) {
             state.validatorErrors = validator.errors;
@@ -67,10 +93,21 @@ export const useValidation = (props: JsonSchemaFormProps, { ajv, formData, local
         return valid;
     };
 
-    const getPropertyInvalidState = (property: InnerJsonSchema): boolean|undefined => {
-        if (props.validationMode === 'all') return !!state.invalidMessages[property.id];
-        if (props.validationMode === 'input' && state.inputOccurred[property.id]) return !!state.invalidMessages[property.id];
+    const getPropertyInvalidState = ({ propertyName }: InnerJsonSchema): boolean|undefined => {
+        if (props.validationMode === 'all') return !!state.invalidMessagesMap[propertyName]?.length;
+        if (props.validationMode === 'input' && state.inputOccurredMap[propertyName]) return !!state.invalidMessagesMap[propertyName]?.length;
         return undefined;
+    };
+
+    const getJsonInputInvalidState = (): boolean|undefined => {
+        if (!props.isRoot) return undefined;
+        if (props.validationMode === 'all') return state.invalidMessages.length > 0;
+        if (props.validationMode === 'input' && state.jsonInputOccurred) return state.invalidMessages.length > 0;
+        return undefined;
+    };
+
+    const setJsonInputParsingError = (e: Error|null) => {
+        state.jsonInputParsingError = e;
     };
 
     watch(() => props.validationMode, (validationMode) => {
@@ -81,6 +118,7 @@ export const useValidation = (props: JsonSchemaFormProps, { ajv, formData, local
         ...toRefs(state),
         validateFormData,
         getPropertyInvalidState,
-
+        getJsonInputInvalidState,
+        setJsonInputParsingError,
     };
 };

--- a/src/inputs/forms/new-json-schema-form/custom-schema.ts
+++ b/src/inputs/forms/new-json-schema-form/custom-schema.ts
@@ -3,21 +3,6 @@ import type Ajv from 'ajv';
 
 export const addCustomFormats = (ajv: Ajv): void => {
     ajv.addFormat('generate_id', true);
-    ajv.addFormat('json', {
-        type: 'string',
-        validate: (value) => {
-            if (!value) return false;
-            try {
-                const parsed = JSON.parse(value);
-                if (typeof parsed !== 'object') return false;
-                if (Array.isArray(parsed)) return false;
-                return true;
-            } catch (e) {
-                return false;
-            }
-            return true;
-        },
-    });
 };
 
 
@@ -32,6 +17,10 @@ export const addCustomKeywords = (ajv: Ajv): void => {
     });
     ajv.addKeyword({
         keyword: 'disabled',
+        schemaType: 'boolean',
+    });
+    ajv.addKeyword({
+        keyword: 'json',
         schemaType: 'boolean',
     });
 };

--- a/src/inputs/forms/new-json-schema-form/mock.ts
+++ b/src/inputs/forms/new-json-schema-form/mock.ts
@@ -81,7 +81,14 @@ export const getDefaultSchema = () => ({
         },
         additional: {
             title: 'Additional Information',
-            format: 'json',
+            type: 'object',
+            json: true,
+            properties: {
+                gender: {
+                    type: 'string',
+                },
+            },
+            required: ['gender'],
         },
 
     },
@@ -95,3 +102,10 @@ export const getDefaultFormData = () => ({
     age: faker.datatype.number(),
     phone: faker.phone.number(),
 });
+
+
+export const getJsonInputSchema = () => {
+    const schema: any = getDefaultSchema();
+    schema.json = true;
+    return schema;
+};

--- a/src/inputs/forms/new-json-schema-form/type.ts
+++ b/src/inputs/forms/new-json-schema-form/type.ts
@@ -6,20 +6,21 @@ import type { SupportLanguage } from '@/translations';
 const TEXT_INPUT_TYPES = ['password', 'text', 'number'] as const;
 export type TextInputType = typeof TEXT_INPUT_TYPES[number]
 
-const COMPONENTS = ['PTextInput', 'GenerateIdFormat', 'PTextEditor', 'PSelectDropdown'] as const;
+const COMPONENTS = ['PTextInput', 'GenerateIdFormat', 'PJsonSchemaForm', 'PSelectDropdown'] as const;
 export type ComponentName = typeof COMPONENTS[number]
 
 export type JsonSchema<Properties = object> = JSONSchemaType<Properties> & {
     title?: string;
     order?: string[];
     disabled?: boolean;
+    json?: boolean;
 }
 
 export const VALIDATION_MODES = ['input', 'all', 'none'] as const;
 export type ValidationMode = typeof VALIDATION_MODES[number]
 
 export type InnerJsonSchema = JsonSchema & {
-    id: string;
+    propertyName: string;
     componentName: ComponentName;
     inputType?: TextInputType;
     inputPlaceholder?: string;
@@ -31,4 +32,5 @@ export interface JsonSchemaFormProps {
     formData?: object;
     language?: SupportLanguage;
     validationMode?: ValidationMode; // default: input
+    isRoot?: boolean;
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

#### Delete the existing `json` format
#### Add `json` keyword which woks with `object` type only
If the type is `object` and the `json` keyword is `true`, TextEditor UI is provided to directly input the object.

1. Non-root case

https://user-images.githubusercontent.com/26986739/192958049-5d1797dc-2ca0-439d-937e-fe75ccff2306.mov

2. Root case

https://user-images.githubusercontent.com/26986739/192957973-228c3cae-0696-40d8-9a0f-cbf194aa1ae3.mov

If `properties` are defined in the schema, properties that are not defined in the corresponding `properties` object are not reflected in the `formData` object that is updated bidirectionally through the `update:form-data` event.
However, if `properties` are not defined, all properties that you write directly are reflected in the `formData` object, so you need to be careful.

---

schema에 properties 가 정의되어 있다면, 해당 properties 객체에 정의되어 있지 않은 속성은 update:form-data 이벤트를 통해 양방향 업데이트되는 formData 객체에 반영되지 않습니다.
하지만 properties 가 정의되어 있지 않다면, 직접 작성하는 모든 속성이 formData 객체에 반영되므로 주의가 필요합니다.



### Things to Talk About
