### PR TITLE
fix(p-page-title): use <span> tag in title

### DIFF
--- a/src/data-display/titles/page-title/PPageTitle.vue
+++ b/src/data-display/titles/page-title/PPageTitle.vue
@@ -10,7 +10,7 @@
             <h2 :class="{'has-left': !!$slots['title-left-extra'], 'has-right': useTotalCount || !!$slots['title-right-extra']}">
                 <slot>
                     <slot name="title">
-                        {{ title }}&zwnj;
+                        <span>{{ title }}&zwnj;</span>
                     </slot>
                 </slot>
             </h2>


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
use `span` tag in title
- before
  ![스크린샷 2022-09-29 오후 9 14 22](https://user-images.githubusercontent.com/18563857/193028502-8d3d2fa6-e6df-4d5b-9dd1-26722f849f7e.png)
- after
  ![스크린샷 2022-09-29 오후 9 13 11](https://user-images.githubusercontent.com/18563857/193028563-75da6e89-33f8-43b7-8974-840a010c0c75.png)