### PR TITLE
fix(p-page-title): remove white space

### DIFF
--- a/src/data-display/titles/page-title/PPageTitle.vue
+++ b/src/data-display/titles/page-title/PPageTitle.vue
@@ -15,12 +15,8 @@
                 </slot>
             </h2>
             <slot v-if="useTotalCount" name="total-count">
-                <span v-if="useSelectedCount && selectedCount" class="total-count">
-                    ({{ $t('COMPONENT.PAGE_TITLE.SELECTED_OF',{ selectedCount, totalCount }) }})
-                </span>
-                <span v-else class="total-count">
-                    ({{ commaFormatter(totalCount) }})
-                </span>
+                <span v-if="useSelectedCount && selectedCount" class="total-count">({{ $t('COMPONENT.PAGE_TITLE.SELECTED_OF',{ selectedCount, totalCount }) }})</span>
+                <span v-else class="total-count">({{ commaFormatter(totalCount) }})</span>
             </slot>
             <slot name="title-right-extra" />
         </div>


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
remove white space in PPageTitle