### PR TITLE
fix(p-lazy-img): fix preloading skeleton position issue

### DIFF
--- a/src/feedbacks/loading/lazy-img/PLazyImg.vue
+++ b/src/feedbacks/loading/lazy-img/PLazyImg.vue
@@ -127,6 +127,7 @@ export default defineComponent<Props>({
     .img-container {
         @apply inline-block w-full h-full absolute rounded-md overflow-hidden;
         z-index: 1;
+        left: 0;
         &.error {
             @apply inline-flex;
         }


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [x] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
- fix preloading skeleton position issue
- add `left` property

![Pasted Graphic 4](https://user-images.githubusercontent.com/83635051/193774715-c0e7029e-5d98-49a3-b4fc-f733e4d9917f.png)


### Things to Talk About
