### PR TITLE
feat(text-input): add right-edge slot and rename right-extra slot to input-right

### DIFF
--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -30,8 +30,11 @@ export const Template = (args, { argTypes }) => ({
                       :masking-mode="maskingMode"
                       :show-password="showPassword"
         >
-            <template v-if="rightExtraSlot" #right-extra>
-                <span v-html="rightExtraSlot"></span>
+            <template v-if="inputRightSlot" #input-right>
+                <span v-html="inputRightSlot"></span>
+            </template>
+            <template v-if="rightEdgeSlot" #right-edge>
+                <span v-html="rightEdgeSlot"></span>
             </template>
         </p-text-input>
     `,
@@ -308,23 +311,37 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
-## Right Extra Slot
+## Slots
 
 <Canvas>
-    <Story name="Right Extra Slot" args={{
+    <Story name="Slots" args={{
         value: 100,
-        rightExtraSlot: '%'
+        inputRightSlot: '%'
     }}>
         {{
-            components: { PTextInput },
+            components: { PTextInput, PButton },
             template: `
-                <p-text-input style="width: 96px;" type="number" multi-input v-model="value" >
-                    <template #right-extra>%</template>
-                </p-text-input>
+<div>
+<p class="text-lg font-bold mb-4">input-right slot</p>
+<p-text-input type="number" multi-input v-model="value" >
+    <template #input-right>%</template>
+</p-text-input>
+<p class="text-lg font-bold my-4">right-edge slot</p>
+<p-text-input multi-input v-model="value2" >
+    <template #right-edge><p-button style-type="primary" size="sm">Click me!</p-button></template>
+</p-text-input>
+<p class="text-lg font-bold my-4">default slot</p>
+<p-text-input multi-input v-model="value2" >
+    <input style="background-color: lavenderblush; padding: 0 0.25rem;" v-model="value3" />
+</p-text-input>
+</div>
+<!-- <div> -->
             `,
             setup() {
                 const state = reactive({
-                    value: 70
+                    value: 70,
+                    value2: 'wanzargen',
+                    value3: 'yuda'
                 })
                 return {
                     ...toRefs(state)

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -38,10 +38,12 @@
                        v-on="inputListeners"
                 >
             </slot>
+            <!-- right-extra slot will be deprecated. use input-right slot. -->
             <span v-if="$slots['right-extra']" class="right-extra">
-                <slot name="right-extra" v-bind="{ value }">
-                    {{ value }}
-                </slot>
+                <slot name="right-extra" v-bind="{ value }" />
+            </span>
+            <span v-if="$slots['input-right']" class="input-right">
+                <slot name="input-right" v-bind="{ value }" />
             </span>
             <p-button v-if="($attrs.type === 'password') && maskingMode"
                       size="sm"
@@ -60,6 +62,9 @@
                  @mousedown.native.prevent
                  @click="handleDeleteAllTags"
             />
+            <span v-if="$slots['right-edge']" class="right-edge">
+                <slot name="right-edge" v-bind="{ value }" />
+            </span>
         </div>
         <p-context-menu v-if="proxyVisibleMenu && useAutoComplete"
                         ref="menuRef"
@@ -469,8 +474,17 @@ export default defineComponent<TextInputProps>({
             }
         }
 
-        > .right-extra {
+        > .right-extra, > .input-right {
             @apply text-gray-400;
+            display: inline-flex;
+            flex-shrink: 0;
+            height: 100%;
+            overflow: hidden;
+            line-height: inherit;
+            font-size: inherit;
+        }
+
+        > .right-edge {
             display: inline-flex;
             flex-shrink: 0;
             height: 100%;

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -336,7 +336,41 @@ export const getTextInputArgTypes = (): ArgTypes => {
         },
         rightExtraSlot: {
             name: 'right-extra',
-            description: 'Slot for right area of input.',
+            description: 'Slot for right area of input. This slot will be deprecated.',
+            defaultValue: '',
+            table: {
+                type: {
+                    summary: null,
+                },
+                defaultValue: {
+                    summary: null,
+                },
+                category: 'slots',
+            },
+            control: {
+                type: 'text',
+            },
+        },
+        inputRightSlot: {
+            name: 'input-right',
+            description: 'Slot on the right next to the input.',
+            defaultValue: '',
+            table: {
+                type: {
+                    summary: null,
+                },
+                defaultValue: {
+                    summary: null,
+                },
+                category: 'slots',
+            },
+            control: {
+                type: 'text',
+            },
+        },
+        rightEdgeSlot: {
+            name: 'right-edge',
+            description: 'Slot on the right edge of the input.',
             defaultValue: '',
             table: {
                 type: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

- Add right-edge slot 

not focused
<img width="271" alt="image" src="https://user-images.githubusercontent.com/26986739/195265295-1af9f755-db4f-487d-815f-728de2fa7a3f.png">

focused
<img width="294" alt="image" src="https://user-images.githubusercontent.com/26986739/195265128-c54242de-2373-435d-afb5-810d4cc0d365.png">

- Rename right-extra slot to input-right slot (right-extra slot is not removed. but will be deprecated.)

not focused
<img width="279" alt="image" src="https://user-images.githubusercontent.com/26986739/195265226-fdf4287e-025f-4b34-83d1-39b25213f348.png">

focused
<img width="258" alt="image" src="https://user-images.githubusercontent.com/26986739/195265353-f21e9111-bf14-44cb-abb9-8fd1ca895c5c.png">


### Things to Talk About
