### PR TITLE
refactor(p-button): change from functional component to single-file component

### DIFF
--- a/src/inputs/buttons/button/PButton.stories.mdx
+++ b/src/inputs/buttons/button/PButton.stories.mdx
@@ -16,7 +16,7 @@ export const Template = (args, {argTypes})=>({
     template: `
         <div style="display:flex; align-items:center; justify-content:center; height:150px;">
             <p-button
-                @click="onClick"
+                @click="handleClick"
                 :href="href"
                 :styleType="styleType"
                 :size="size"
@@ -103,6 +103,9 @@ export const Template = (args, {argTypes})=>({
                         </p-button>
                     </div>
                     <div style="display:flex; margin-top: 20px">
+                        <p-button styleType="secondary-dark" style="margin-right: 20px">
+                            <div>secondary-dark</div>
+                        </p-button>
                         <p-button styleType="secondary" style="margin-right: 20px">
                             <div>secondary</div>
                         </p-button>
@@ -114,9 +117,6 @@ export const Template = (args, {argTypes})=>({
                         </p-button>
                         <p-button styleType="gray900" style="margin-right: 20px">
                             <div>gray900</div>
-                        </p-button>
-                        <p-button styleType="gray900-hover" style="margin-right: 20px">
-                            <div>gray900-hover</div>
                         </p-button>
                     </div>
                     <div style="display:flex; margin-top: 20px">

--- a/src/inputs/buttons/button/story-helper.ts
+++ b/src/inputs/buttons/button/story-helper.ts
@@ -42,21 +42,6 @@ export const getButtonArgTypes = (): ArgTypes => ({
             options: ['md', 'sm', 'lg'],
         },
     },
-    default: {
-        name: 'default',
-        type: { name: 'string' },
-        description: 'Slot for contents of button',
-        defaultValue: 'button',
-        table: {
-            type: {
-                summary: null,
-            },
-            category: 'slots',
-        },
-        control: {
-            type: 'text',
-        },
-    },
     href: {
         name: 'href',
         type: { name: 'string' },
@@ -185,8 +170,24 @@ export const getButtonArgTypes = (): ArgTypes => ({
             options: [null, ...Object.keys(icon.icons)],
         },
     },
+    // slots
+    default: {
+        name: 'default',
+        type: { name: 'string' },
+        description: 'Slot for contents of button',
+        defaultValue: 'button',
+        table: {
+            type: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+        control: {
+            type: 'text',
+        },
+    },
     // events
-    onClick: {
+    handleClick: {
         name: 'click',
         type: { name: 'function' },
         description: 'Click function',

--- a/src/inputs/buttons/button/type.ts
+++ b/src/inputs/buttons/button/type.ts
@@ -1,4 +1,4 @@
-export const BUTTON_STYLE = Object.freeze({
+export const BUTTON_STYLE = {
     'primary-dark': 'primary-dark',
     primary: 'primary',
     primary1: 'primary1',
@@ -12,20 +12,18 @@ export const BUTTON_STYLE = Object.freeze({
     safe: 'safe',
     'gray-border': 'gray-border',
     transparent: 'transparent',
-    // 'gray900-hover' = 'gray900-hover',
-    // 'gray900-border' = 'gray900-border'
-} as const);
+} as const;
 
-export const BUTTON_SIZE = Object.freeze({
+export const BUTTON_SIZE = {
     sm: 'sm',
     md: 'md',
     lg: 'lg',
-}as const);
+} as const;
 
-export const BUTTON_FONT_WEIGHT = Object.freeze({
+export const BUTTON_FONT_WEIGHT = {
     normal: 'normal',
     bold: 'bold',
-} as const);
+} as const;
 
 export type ButtonStyle = typeof BUTTON_STYLE[keyof typeof BUTTON_STYLE];
 export type ButtonSize = typeof BUTTON_SIZE[keyof typeof BUTTON_SIZE];


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [x] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description
SSIA. Appearance is the same as before.

### Things to Talk About
I think it's good to change all functional components into a **single-file components**. :)
> In 3.x, the performance difference between stateful and functional components has been drastically reduced and will be insignificant in most use cases. - [Vue3 Migration Guide](https://v3-migration.vuejs.org/breaking-changes/functional-components.html#single-file-components-sfcs)