### PR TITLE
fix(bredcrumbs): fix breadcrumbs word-break

### DIFF
--- a/src/navigation/breadcrumbs/PBreadcrumbs.vue
+++ b/src/navigation/breadcrumbs/PBreadcrumbs.vue
@@ -6,8 +6,8 @@
                     v-if="isLengthOverFive(idx)" class="menu"
                     :to="getLocation(route)"
                 >
-                    <span v-if="idx !== routes.length - 1" class="inline-block link">{{ route.name }}</span>
-                    <span v-else class="inline-block current-page">
+                    <span v-if="idx !== routes.length - 1" class="link">{{ route.name }}</span>
+                    <span v-else class="current-page">
                         {{ route.name }}
                         <p-copy-button v-if="copiable" :value="route.name" />
                     </span>
@@ -19,11 +19,11 @@
                 </router-link>
             </span>
             <span v-else>
-                <div v-if="isLengthOverFive(idx)" class="menu">
-                    <span v-if="idx !== routes.length - 1" class="inline-block link"
+                <span v-if="isLengthOverFive(idx)" class="menu">
+                    <span v-if="idx !== routes.length - 1" class="link"
                           @click="$emit('click', route, idx)"
                     >{{ route.name }}</span>
-                    <span v-else class="inline-block current-page">
+                    <span v-else class="current-page">
                         {{ route.name }}
                         <p-copy-button v-if="copiable" :value="route.name" />
                     </span>
@@ -32,10 +32,10 @@
                              class="arrow-icon" color="inherit white"
                         />
                     </span>
-                </div>
+                </span>
             </span>
             <span v-if="routes.length >= 5 && idx === 2 && !state.isShown">
-                <span class="inline-block link" @click="showHidden">...</span>
+                <span class="link" @click="showHidden">...</span>
                 <p-i name="ic_breadcrumb_arrow" width="1rem" height="1rem"
                      class="arrow-icon" color="inherit white"
                 />
@@ -104,8 +104,9 @@ export default defineComponent<Props>({
 
 <style lang="postcss">
 .p-breadcrumbs {
-    display: inline-flex;
-
+    .menu {
+        word-break: break-all;
+    }
     .link {
         @apply text-xs text-gray-700 cursor-pointer;
 
@@ -113,17 +114,14 @@ export default defineComponent<Props>({
             @apply text-gray-900 underline;
         }
     }
-
     .current-page {
         @apply text-xs text-gray-900 cursor-default;
-        display: inline-flex;
-        align-items: center;
         > .p-copy-button {
             font-size: inherit;
             margin-left: 0.25rem;
+            vertical-align: 0.1rem;
         }
     }
-
     .arrow-icon {
         @apply text-gray-500;
         margin-left: 0.375rem;


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [X] Bug fixes
- [X] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [X] Updated Storybook documents
- [X] Tested with console

### Description
* Issue: [[Project] When multiple project groups with long names are nested, the text in breadcrumbs is broken #143](https://github.com/spaceone-dev/feedback/issues/143)
* After removing `inline-block` and `inline-flex` to apply `word-break: break-all;`, modify the role played by the corresponding css to another css (`vertical-align:0.1rem`)
* Placing `<div></div>` tags inside `<span></span>` tags is against web standards, and it is corrected.

---

* 이슈: [[Project] When multiple project groups with long names are nested, the text in breadcrumbs is broken #143](https://github.com/spaceone-dev/feedback/issues/143)
* `word-break: break-all;`적용하기 위해 `inline-block`와 `inline-flex` 를 제거 한 후 해당 css가 했던 역할을 다른 css(`vertical-align:0.1rem`)로 수정
* `<span></span>` 태그 안에 `<div></div>`태그를 두는 것은 웹표준에 위배 되어 이를 수정

---

**수정 전**
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/19162140/195287008-92e0625b-b5b5-4103-b7b1-f007e7ba19af.png">

**수정 후**
<img width="675" alt="image" src="https://user-images.githubusercontent.com/19162140/195287208-22346961-6641-47b8-9ce6-578957c43e0a.png">

### Things to Talk About
