### PR TITLE
feat(p-data-table): add disableCopy option to DataTableField

### DIFF
--- a/src/data-display/tables/data-table/PDataTable.stories.mdx
+++ b/src/data-display/tables/data-table/PDataTable.stories.mdx
@@ -91,6 +91,7 @@ interface DataTableFieldType {
     label?: string;
     sortable?: boolean;
     sortKey?: string;
+    disableCopy?: boolean;
     width?: string;
     textAlign?: DataTableCellTextAlign;
     children?: DataTableFieldType[];
@@ -105,6 +106,7 @@ interface DataTableFieldType {
 |label|Display name for the column(field) head.|
 |sortable|Whether to sortable the table by the column or not. If it's not given, it follows the `sortable` props.|
 |sortKey|If you give the value to this property, the value of `sortBy` passed to the `changeSort` and `update:sortBy` events is replaced with this value when sorting based on the corresponding column. default is the column `name`.|
+|disableCopy|Use it when you want to disable copy functions in some columns.|
 |width|If you want to fix the cell width, give the value.|
 |textAlign|If you want to align text in the cell, give the value. <Description markdown={`${Object.values(DATA_TABLE_CELL_TEXT_ALIGN).map(d => `\`${d}\``).join(', ')} are available.`}/> |
 |children|If you want to make a header cell span over multiple columns, give child fields to this property.|

--- a/src/data-display/tables/data-table/PDataTable.vue
+++ b/src/data-display/tables/data-table/PDataTable.vue
@@ -45,7 +45,7 @@
                                                 >
                                                     {{ field.label ? field.label : field.name }}
                                                 </slot>
-                                                <p-copy-button v-if="colCopy && isLeafField(field)"
+                                                <p-copy-button v-if="colCopy && !field.disableCopy && isLeafField(field)"
                                                                copy-manually
                                                                @copy="onClickColCopy(field)"
                                                 />

--- a/src/data-display/tables/data-table/type.ts
+++ b/src/data-display/tables/data-table/type.ts
@@ -16,6 +16,7 @@ export interface DataTableFieldType {
     label?: string;
     sortable?: boolean;
     sortKey?: string;
+    disableCopy?: boolean;
     width?: string;
     textAlign?: DataTableCellTextAlign;
     children?: DataTableFieldType[];


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

The `disableCopy` property has been added to the field to allow the colCopy function to be applied to each column.


### Things to Talk About
