### PR TITLE
feat(select-card): add `keydown` selecting event & add `bottom slot`

### DIFF
--- a/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/src/inputs/select-card/PSelectCard.stories.mdx
@@ -300,10 +300,10 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-## Extra Slot
+## Bottom Slot
 
 <Canvas>
-    <Story name="Extra Slot">
+    <Story name="Bottom Slot">
         {{
             components: { PSelectCard, PAnchor },
             template: `
@@ -315,7 +315,7 @@ export const Template = (args, { argTypes }) => ({
             :icon="icons[index]"
             style="min-width: 8rem; min-height: 8rem; margin: 1rem;"
         >
-            <template #extra>
+            <template #bottom>
                 <p-anchor highlight>Preview</p-anchor>
             </template>
         </p-select-card>

--- a/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/src/inputs/select-card/PSelectCard.stories.mdx
@@ -311,8 +311,9 @@ export const Template = (args, { argTypes }) => ({
         <p-select-card v-for="(value, index) in values" :key="value"
             :value="value"
             v-model="selected"
-            label="Label"
+            :label="icons[index]"
             :icon="icons[index]"
+            :tab-index="index"
             style="min-width: 8rem; min-height: 8rem; margin: 1rem;"
         >
             <template #bottom>

--- a/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/src/inputs/select-card/PSelectCard.stories.mdx
@@ -64,7 +64,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="w-full overflow p-8 flex flex-wrap">
-        <p-select-card v-for="value in values" :key="value"
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :tab-index="index"
             :value="value"
             v-model="selected"
             :icon="icons[value]"
@@ -98,7 +99,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="h-full w-full overflow p-8">
-        <p-select-card v-for="value in values" :key="value"
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :tab-index="index"
             :value="value" block
             v-model="selected"
             :icon="icons[value]"
@@ -132,7 +134,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="h-full w-full overflow p-8">
-        <p-select-card v-for="value in values" :key="value"
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :tab-index="index"
             :value="value" block
             v-model="selected"
             :label="icons[value]"
@@ -166,7 +169,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="h-full w-full overflow p-8">
-        <p-select-card v-for="value in values" :key="value"
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :tab-index="index"
             :value="value"
             v-model="selected"
             :label="'label-' + value"
@@ -200,7 +204,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="w-full overflow p-8 flex flex-wrap">
-        <p-select-card v-for="value in values" :key="value"
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :tab-index="index"
             multi-selectable
             :value="value"
             v-model="selected"
@@ -236,7 +241,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="w-full overflow p-8 grid gap-4 grid-cols-3">
-        <p-select-card v-for="value in values" :key="value.key"
+        <p-select-card v-for="(value, index) in values" :key="value.key"
+            :tab-index="index"
             v-model="selected"
             :value="value"
             :label="value.name"
@@ -277,7 +283,8 @@ export const Template = (args, { argTypes }) => ({
             components: { PSelectCard },
             template: `
     <div class="w-full overflow p-8 flex flex-wrap">
-        <p-select-card v-for="value in values" :key="value"
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :tab-index="index"
             :value="value"
             v-model="selected"
             style="min-width: 8rem; min-height: 8rem; margin: 1rem;"

--- a/src/inputs/select-card/PSelectCard.stories.mdx
+++ b/src/inputs/select-card/PSelectCard.stories.mdx
@@ -8,6 +8,7 @@ import { getAllAvailableIcons } from '@/foundation/icons/story-helper';
 import { getSelectCardArgTypes } from '@/inputs/select-card/story-helper';
 import PSelectCard from './PSelectCard.vue';
 import { peacock } from '@/styles/colors'
+import PAnchor from '@/inputs/anchors/PAnchor';
 
 <Meta title='Inputs/Select Card' parameters={{
     design: {
@@ -289,6 +290,42 @@ export const Template = (args, { argTypes }) => ({
                 const state = reactive({
                     selected: undefined,
                     values: range(8).map(d => peacock[(d + 1) * 100]),
+                })
+                return {
+                    ...toRefs(state),
+                    peacock
+                };
+            }
+        }}
+    </Story>
+</Canvas>
+
+## Extra Slot
+
+<Canvas>
+    <Story name="Extra Slot">
+        {{
+            components: { PSelectCard, PAnchor },
+            template: `
+    <div class="w-full overflow p-8 flex flex-wrap">
+        <p-select-card v-for="(value, index) in values" :key="value"
+            :value="value"
+            v-model="selected"
+            label="Label"
+            :icon="icons[index]"
+            style="min-width: 8rem; min-height: 8rem; margin: 1rem;"
+        >
+            <template #extra>
+                <p-anchor highlight>Preview</p-anchor>
+            </template>
+        </p-select-card>
+    </div>
+    `,
+            setup(props) {
+                const state = reactive({
+                    selected: undefined,
+                    values: range(4).map(d => peacock[(d + 1) * 100]),
+                    icons: getAllAvailableIcons(),
                 })
                 return {
                     ...toRefs(state),

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -40,7 +40,7 @@ interface Props extends SelectProps {
     icon?: string|boolean;
     iconColor?: string;
     label?: string;
-    tabIndex?: number;
+    tabIndex?: number|undefined;
 }
 // FIXME:: tabIndex should be a required member;
 
@@ -144,14 +144,13 @@ export default defineComponent<Props>({
         };
 
         // FIXME:: Modularize keyboard event
-        const handleKeydown = (e) => {
+        const handleKeydown = (e: KeyboardEvent) => {
             if (typeof props.tabIndex !== 'number'
                 || !['ArrowRight', 'ArrowLeft'].includes(e.key)
             ) return;
 
-
-            // sibling means other cards on same depth
-            const siblings = e.target.parentElement.children as HTMLCollectionOf<HTMLDivElement>;
+            // sibling means other cards on the same depth
+            const siblings = (e?.target as HTMLDivElement)?.parentElement?.children as HTMLCollectionOf<HTMLDivElement>;
             const lastIndex = siblings.length - 1;
 
             let nextTarget = 0;

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -14,7 +14,7 @@
                 />
                 <span v-if="label" class="label">{{ label }}</span>
             </slot>
-            <slot name="extra" />
+            <slot name="bottom" />
         </div>
     </div>
 </template>

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -146,7 +146,8 @@ export default defineComponent<Props>({
         // FIXME:: Modularize keyboard event
         const handleKeydown = (e: KeyboardEvent) => {
             if (typeof props.tabIndex !== 'number'
-                || !['ArrowRight', 'ArrowLeft'].includes(e.key)
+                || !e.key.includes('Arrow')
+                || props.multiSelectable
             ) return;
 
             // sibling means other cards on the same depth
@@ -154,10 +155,10 @@ export default defineComponent<Props>({
             const lastIndex = siblings.length - 1;
 
             let nextTarget = 0;
-            if (e.key === 'ArrowRight') {
+            if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
                 if (props.tabIndex === lastIndex) nextTarget = 0;
                 else nextTarget = props.tabIndex + 1;
-            } else if (e.key === 'ArrowLeft') {
+            } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
                 if (props.tabIndex === 0) nextTarget = lastIndex;
                 else nextTarget = props.tabIndex - 1;
             }

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -2,9 +2,9 @@
     <div class="p-select-card"
          :class="{selected: isSelected, block, disabled}"
          :tabindex="tabIndex"
-         @click="onClick"
+         @click="handleClick"
          v-on="$listeners"
-         @keydown="onKeydown"
+         @keydown="handleKeydown"
     >
         <p-i :name="markerIconName"
              class="marker" width="1.25rem" height="1.25rem"
@@ -42,7 +42,7 @@ interface Props extends SelectProps {
     label?: string;
     tabIndex?: number;
 }
-// FIXME:: tabIndex should be required member;
+// FIXME:: tabIndex should be a required member;
 
 
 export default defineComponent<Props>({
@@ -134,7 +134,7 @@ export default defineComponent<Props>({
         });
 
         /* event */
-        const onClick = () => {
+        const handleClick = () => {
             const newSelected = getSelected();
             if (props.multiSelectable) {
                 emit('change', newSelected, !isSelected.value);
@@ -143,8 +143,8 @@ export default defineComponent<Props>({
             }
         };
 
-        // FIXME:: Modularization keyboard event
-        const onKeydown = (e) => {
+        // FIXME:: Modularize keyboard event
+        const handleKeydown = (e) => {
             if (typeof props.tabIndex !== 'number'
                 || !['ArrowRight', 'ArrowLeft'].includes(e.key)
             ) return;
@@ -170,8 +170,8 @@ export default defineComponent<Props>({
         return {
             ...toRefs(state),
             isSelected,
-            onClick,
-            onKeydown,
+            handleClick,
+            handleKeydown,
         };
     },
 });

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -100,7 +100,7 @@ export default defineComponent<Props>({
         },
         tabIndex: {
             type: Number,
-            default: 0,
+            default: undefined,
         },
     },
     setup(props, { emit }: SetupContext) {

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -1,7 +1,10 @@
 <template>
-    <div class="p-select-card" :class="{selected: isSelected, block, disabled}"
+    <div class="p-select-card"
+         :class="{selected: isSelected, block, disabled}"
+         :tabindex="tabIndex"
          @click="onClick"
          v-on="$listeners"
+         @keydown="onKeydown"
     >
         <p-i :name="markerIconName"
              class="marker" width="1.25rem" height="1.25rem"
@@ -37,7 +40,10 @@ interface Props extends SelectProps {
     icon?: string|boolean;
     iconColor?: string;
     label?: string;
+    tabIndex?: number;
 }
+// FIXME:: tabIndex should be required member;
+
 
 export default defineComponent<Props>({
     name: 'PSelectCard',
@@ -92,6 +98,10 @@ export default defineComponent<Props>({
             type: String,
             default: '',
         },
+        tabIndex: {
+            type: Number,
+            default: 0,
+        },
     },
     setup(props, { emit }: SetupContext) {
         const {
@@ -133,10 +143,35 @@ export default defineComponent<Props>({
             }
         };
 
+        // FIXME:: Modularization keyboard event
+        const onKeydown = (e) => {
+            if (typeof props.tabIndex !== 'number'
+                || !['ArrowRight', 'ArrowLeft'].includes(e.key)
+            ) return;
+
+
+            // sibling means other cards on same depth
+            const siblings = e.target.parentElement.children as HTMLCollectionOf<HTMLDivElement>;
+            const lastIndex = siblings.length - 1;
+
+            let nextTarget = 0;
+            if (e.key === 'ArrowRight') {
+                if (props.tabIndex === lastIndex) nextTarget = 0;
+                else nextTarget = props.tabIndex + 1;
+            } else if (e.key === 'ArrowLeft') {
+                if (props.tabIndex === 0) nextTarget = lastIndex;
+                else nextTarget = props.tabIndex - 1;
+            }
+
+            siblings[nextTarget].focus();
+            siblings[nextTarget].click();
+        };
+
         return {
             ...toRefs(state),
             isSelected,
             onClick,
+            onKeydown,
         };
     },
 });

--- a/src/inputs/select-card/PSelectCard.vue
+++ b/src/inputs/select-card/PSelectCard.vue
@@ -14,11 +14,13 @@
                 />
                 <span v-if="label" class="label">{{ label }}</span>
             </slot>
+            <slot name="extra" />
         </div>
     </div>
 </template>
 
 <script lang="ts">
+import type { SetupContext } from 'vue';
 import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
@@ -91,7 +93,7 @@ export default defineComponent<Props>({
             default: '',
         },
     },
-    setup(props: Props, { emit }) {
+    setup(props, { emit }: SetupContext) {
         const {
             isSelected,
             getSelected,

--- a/src/inputs/select-card/story-helper.ts
+++ b/src/inputs/select-card/story-helper.ts
@@ -201,10 +201,45 @@ export const getSelectCardArgTypes = (): ArgTypes => ({
             type: 'text',
         },
     },
+    tabIndex: {
+        name: 'tabIndex',
+        type: { name: 'number' },
+        description: 'Tab Index, used for keydown event and Web Accessibility',
+        defaultValue: 0,
+        table: {
+            type: {
+                summary: 'number',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 0,
+            },
+        },
+        control: {
+            type: 'number',
+        },
+    },
     /* slot */
     defaultSlot: {
         name: 'default',
         description: 'Slot for card contents.',
+        defaultValue: '',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'slots',
+        },
+        control: {
+            type: 'text',
+        },
+    },
+    bottom: {
+        name: 'bottom',
+        description: 'Bottom slot for extra contents',
         defaultValue: '',
         table: {
             type: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [ ] Tested with console

### Description

## Selected cards could be selected by keyboard event.
- `Arrow Right, Arrow Down` select the next card
- `Arrow Left, Arrow Up` select the previous card
- If prop `multi-selectable` is `true`, Do not fire keyboard event (It rather decrease UX)
- prop `tab-index` should be required for using the keyboard event

## Bottom Slot has been created
- The default slot has limitations for extra contents, so I've created it.

https://user-images.githubusercontent.com/29014433/195320554-987e80a7-6aee-4636-b41c-2a36a84c6a1a.mov



### Things to Talk About
