### PR TITLE
fix(p-tag): fix side effect in default slot

### DIFF
--- a/src/data-display/tags/PTag.vue
+++ b/src/data-display/tags/PTag.vue
@@ -9,13 +9,13 @@
              width="0.8rem"
              height="0.8rem"
         />
-        <slot name="default">
-            <span class="tag-contents">
+        <span class="tag-contents">
+            <slot name="default">
                 <span v-if="categoryItem" class="category"><slot name="category">[{{ categoryItem.label || categoryItem.name }}]</slot></span>
                 <span v-if="keyItem" class="key"><slot name="key">{{ keyItem.label || keyItem.name }}:</slot></span>
                 <span v-if="valueItem"><slot name="value">{{ valueItem.label || valueItem.name }}</slot></span>
-            </span>
-        </slot>
+            </slot>
+        </span>
         <p-i v-if="deletable"
              name="ic_delete"
              width="1rem"


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [ ] Tested with console

### Description
- move default slot to tag-contents span for handling side effect

### Things to Talk About
