### PR TITLE
fix(query-search-dropdown): add duplicated query-item handling spec

### DIFF
--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
@@ -147,6 +147,8 @@ export default defineComponent<QuerySearchDropdownProps>({
 
         /* util */
         const selectItem = (queryItem: QueryItem) => {
+            const duplicatedIndex = state.proxySelected.findIndex(item => item.key.label === queryItem.key?.label || item.key.name === queryItem.key?.name);
+            if (duplicatedIndex !== -1) state.proxySelected.splice(duplicatedIndex, 1);
             if (props.multiSelectable) {
                 state.proxySelected = [...state.proxySelected, queryItem];
             } else {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
- Add spec handling duplicate-key case in query items
- In `selectItem` util function, check duplicate-status and remove duplicate-item