### PR TITLE
fix(search-dropdown): fix done-button not working issue

### DIFF
--- a/src/inputs/context-menu/PContextMenu.vue
+++ b/src/inputs/context-menu/PContextMenu.vue
@@ -8,7 +8,9 @@
                     <b>{{ $t('COMPONENT.CONTEXT_MENU.SELECTED_LIST') }}</b>
                     <span class="pl-2">({{ selectedCountInFilteredMenu }} / {{ menuItemLength }})</span>
                 </div>
-                <p-button size="sm" style-type="primary-dark" :disabled="!proxySelected.length">
+                <p-button size="sm" style-type="primary-dark" :disabled="!proxySelected.length"
+                          @click="$emit('click-done', $event)"
+                >
                     {{ $t('COMPONENT.CONTEXT_MENU.DONE') }}
                 </p-button>
             </div>

--- a/src/inputs/context-menu/story-helper.ts
+++ b/src/inputs/context-menu/story-helper.ts
@@ -21,6 +21,7 @@ const events: [string, string][] = [
     ['keyup:down:end', 'This event is emitted when a menu item is tracked through the arrow down key, and the down key is pressed at the last menu item.'],
     ['keyup:esc', 'This event is emitted when a esc key is pressed.'],
     ['click-button', 'This event is emitted when the button(in the item whose type is button) is clicked. As arguments, item, index and click event will be passed.'],
+    ['click-done', 'This event is emitted when the done-button(in multi-selectable case) is clicked.'],
 ];
 
 const getArgTypes = (category: string, info: [string, string][]) => {

--- a/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
+++ b/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
@@ -60,6 +60,7 @@
                         @keyup:up:end="focusSearch"
                         @keyup:esc="focusSearch"
                         @focus="onFocusMenuItem"
+                        @click-done="forceHideMenu"
         >
             <template #item--format="{item}">
                 <span class="p-search-dropdown__item-label">


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description
- Add `click-done` event to `context-menu`
- Bind `forceHideMenu` event in `search-dropdown` to `context-menu`
- Update `context-menu` docs
- [console QA-307](https://pyengine.atlassian.net/jira/software/projects/QA/boards/23?selectedIssue=QA-307)

![스크린샷 2022-10-20 오후 1 25 19](https://user-images.githubusercontent.com/83635051/196856318-e966098e-a033-4e65-a579-91ae473265ca.png)
[here](https://spaceone.console.doodle.spaceone.dev/cost-explorer/cost-analysis)