### PR TITLE
feat(p-json-schema-form): add `array` type

### DIFF
--- a/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
@@ -65,7 +65,7 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 |string type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
 |number type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
 |integer type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
-|array type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
+|array type|ajv|[Text Input](?path=/docs/inputs-input--basic) or [Search Dropdown](?path=/docs/inputs-dropdown-search-dropdown--basic)(with enum keyword)||
 |password format|ajv-format|[Text Input](?path=/docs/inputs-input--basic)|
 |markdown keyword|custom|[Markdown](?path=/docs/data-display-markdown--string-markdown)|
 |generate_id format|custom|GenerateIdFormat (Internal Component)|

--- a/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
+++ b/src/inputs/forms/json-schema-form/PJsonSchemaForm.stories.mdx
@@ -65,6 +65,7 @@ It internally uses [Ajv JSON schema validator](https://ajv.js.org/) and [ajv-for
 |string type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
 |number type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
 |integer type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
+|array type|ajv|[Text Input](?path=/docs/inputs-input--basic)|
 |password format|ajv-format|[Text Input](?path=/docs/inputs-input--basic)|
 |markdown keyword|custom|[Markdown](?path=/docs/data-display-markdown--string-markdown)|
 |generate_id format|custom|GenerateIdFormat (Internal Component)|

--- a/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
@@ -55,16 +55,26 @@
                                        :disabled="schemaProperty.disabled"
                                        @update:selected="handleUpdateFormValue(schemaProperty, ...arguments)"
                     />
-                    <p-text-input v-else
-                                  :value="rawFormData[schemaProperty.propertyName]"
-                                  :type="schemaProperty.inputType"
-                                  :invalid="invalid"
-                                  :placeholder="schemaProperty.inputPlaceholder"
-                                  :masking-mode="schemaProperty.inputType === 'password'"
-                                  :autocomplete="false"
-                                  :disabled="schemaProperty.disabled"
-                                  @update:value="handleUpdateFormValue(schemaProperty, ...arguments)"
-                    />
+                    <template v-else>
+                        <p-text-input v-if="schemaProperty.type === 'array'"
+                                      :selected="rawFormData[schemaProperty.propertyName]"
+                                      :type="schemaProperty.inputType"
+                                      :invalid="invalid"
+                                      :placeholder="schemaProperty.inputPlaceholder"
+                                      :disabled="schemaProperty.disabled"
+                                      multi-input
+                                      @update:selected="handleUpdateFormValue(schemaProperty, ...arguments)"
+                        />
+                        <p-text-input v-else
+                                      :value="rawFormData[schemaProperty.propertyName]"
+                                      :type="schemaProperty.inputType"
+                                      :invalid="invalid"
+                                      :placeholder="schemaProperty.inputPlaceholder"
+                                      :masking-mode="schemaProperty.inputType === 'password'"
+                                      :disabled="schemaProperty.disabled"
+                                      @update:value="handleUpdateFormValue(schemaProperty, ...arguments)"
+                        />
+                    </template>
                 </template>
             </p-field-group>
         </template>

--- a/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
@@ -56,23 +56,17 @@
                                        @update:selected="handleUpdateFormValue(schemaProperty, ...arguments)"
                     />
                     <template v-else>
-                        <p-text-input v-if="schemaProperty.type === 'array'"
-                                      :selected="rawFormData[schemaProperty.propertyName]"
-                                      :type="schemaProperty.inputType"
-                                      :invalid="invalid"
-                                      :placeholder="schemaProperty.inputPlaceholder"
-                                      :disabled="schemaProperty.disabled"
-                                      multi-input
-                                      @update:selected="handleUpdateFormValue(schemaProperty, ...arguments)"
-                        />
-                        <p-text-input v-else
-                                      :value="rawFormData[schemaProperty.propertyName]"
+                        <p-text-input :value="schemaProperty.multiInputMode ? undefined : rawFormData[schemaProperty.propertyName]"
+                                      :selected="schemaProperty.multiInputMode ? rawFormData[schemaProperty.propertyName] : undefined"
                                       :type="schemaProperty.inputType"
                                       :invalid="invalid"
                                       :placeholder="schemaProperty.inputPlaceholder"
                                       :masking-mode="schemaProperty.inputType === 'password'"
+                                      :autocomplete="false"
                                       :disabled="schemaProperty.disabled"
-                                      @update:value="handleUpdateFormValue(schemaProperty, ...arguments)"
+                                      :multi-input="schemaProperty.multiInputMode"
+                                      @update:value="!schemaProperty.multiInputMode && handleUpdateFormValue(schemaProperty, ...arguments)"
+                                      @update:selected="schemaProperty.multiInputMode && handleUpdateFormValue(schemaProperty, ...arguments)"
                         />
                     </template>
                 </template>
@@ -183,6 +177,7 @@ export default defineComponent<JsonSchemaFormProps>({
                             inputType: getInputTypeBySchemaProperty(schemaProperty),
                             inputPlaceholder: getInputPlaceholderBySchemaProperty(schemaProperty),
                             menuItems: getMenuItemsBySchemaProperty(schemaProperty),
+                            multiInputMode: schemaProperty.type === 'array',
                         };
                         return refined;
                     }).sort((a, b) => {

--- a/src/inputs/forms/json-schema-form/helper.ts
+++ b/src/inputs/forms/json-schema-form/helper.ts
@@ -1,6 +1,8 @@
+import { cloneDeep } from 'lodash';
+
 import type { SelectDropdownMenu } from '@/inputs/dropdown/select-dropdown/type';
 import type {
-    JsonSchema, InnerJsonSchema, ComponentName, TextInputType,
+    ComponentName, InnerJsonSchema, JsonSchema, TextInputType,
 } from '@/inputs/forms/json-schema-form/type';
 
 export const NUMERIC_TYPES = ['number', 'integer'];
@@ -15,10 +17,17 @@ const refineNumberTypeValue = (val: any): any => {
     return dataValue;
 };
 
+const refineArrayTypeValue = (val?: any[]): string[] | undefined => {
+    if (!val?.length) return undefined;
+    if (typeof val[0] === 'string') return val;
+    return val.map(d => d.value);
+};
+
 export const refineValueByProperty = (schema: JsonSchema, val?: any): any => {
     const { type, disabled } = schema;
     if (disabled) return undefined;
     if (type === 'object') return val; // In case of object, child JsonSchemaForm refines the data.
+    if (type === 'array') return refineArrayTypeValue(val);
     if (NUMERIC_TYPES.includes(type)) return refineNumberTypeValue(val);
     if (typeof val === 'string') return val?.trim() || undefined;
     return undefined;
@@ -32,6 +41,9 @@ export const initFormDataWithSchema = (schema?: JsonSchema, formData?: object): 
     Object.keys(properties).forEach((key) => {
         const property = properties[key];
         result[key] = formData?.[key] ?? property.default ?? undefined;
+        if (property.type === 'array' && result[key]) { // array type needs conversion for component.
+            result[key] = cloneDeep(result[key]).map(d => ({ value: d }));
+        }
     });
     return result;
 };

--- a/src/inputs/forms/json-schema-form/helper.ts
+++ b/src/inputs/forms/json-schema-form/helper.ts
@@ -1,5 +1,3 @@
-import { cloneDeep } from 'lodash';
-
 import type { SelectDropdownMenu } from '@/inputs/dropdown/select-dropdown/type';
 import type {
     ComponentName, InnerJsonSchema, JsonSchema, TextInputType,
@@ -42,7 +40,11 @@ export const initFormDataWithSchema = (schema?: JsonSchema, formData?: object): 
         const property = properties[key];
         result[key] = formData?.[key] ?? property.default ?? undefined;
         if (property.type === 'array' && result[key]) { // array type needs conversion for component.
-            result[key] = cloneDeep(result[key]).map(d => ({ value: d }));
+            if (!Array.isArray(result[key])) {
+                result[key] = undefined;
+            } else {
+                result[key] = result[key].map(d => ({ value: d }));
+            }
         }
     });
     return result;

--- a/src/inputs/forms/json-schema-form/mock.ts
+++ b/src/inputs/forms/json-schema-form/mock.ts
@@ -61,6 +61,7 @@ export const getDefaultSchema = () => ({
             examples: [
                 'user1@test.com, user2@test.com',
             ],
+            default: ['user1@test.com'],
             uniqueItems: true,
         },
         homepage: {

--- a/src/inputs/forms/json-schema-form/mock.ts
+++ b/src/inputs/forms/json-schema-form/mock.ts
@@ -52,13 +52,16 @@ export const getDefaultSchema = () => ({
         emails: {
             description: 'Email addresses',
             title: 'Email Addresses',
-            minLength: 10,
             type: 'array',
-            pattern: '^[\\W]*([\\w+\\-.%]+@[\\w\\-.]+\\.[A-Za-z]{2,4}[\\W]*,{1}[\\W]*)*([\\w+\\-.%]+@[\\w\\-.]+\\.[A-Za-z]{2,4})[\\W]*$',
-            items: [{ type: 'string' }],
+            items: {
+                type: 'string',
+                minLength: 10,
+                pattern: '^[\\W]*([\\w+\\-.%]+@[\\w\\-.]+\\.[A-Za-z]{2,4}[\\W]*,{1}[\\W]*)*([\\w+\\-.%]+@[\\w\\-.]+\\.[A-Za-z]{2,4})[\\W]*$',
+            },
             examples: [
                 'user1@test.com, user2@test.com',
             ],
+            uniqueItems: true,
         },
         homepage: {
             type: 'string',
@@ -92,7 +95,7 @@ export const getDefaultSchema = () => ({
         },
 
     },
-    required: ['user_id', 'password', 'user_name', 'age', 'homepage', 'phone', 'additional'],
+    required: ['user_id', 'password', 'user_name', 'age', 'homepage', 'phone', 'additional', 'emails'],
     order: ['user_id', 'password', 'user_name', 'user_nickname', 'country_code', 'age', 'phone', 'homepage', 'additional'],
 });
 

--- a/src/inputs/forms/json-schema-form/type.ts
+++ b/src/inputs/forms/json-schema-form/type.ts
@@ -25,6 +25,7 @@ export type InnerJsonSchema = JsonSchema & {
     inputType?: TextInputType;
     inputPlaceholder?: string;
     menuItems?: SelectDropdownMenu[];
+    multiInputMode?: boolean;
 }
 
 export interface JsonSchemaFormProps {

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -387,9 +387,7 @@ export default defineComponent<TextInputProps>({
         const init = () => {
             state.filteredMenu = props.menu;
             if (props.selected && props.multiInput) {
-                if (Array.isArray(props.selected)) {
-                    state.proxySelectedValue = props.selected;
-                } else {
+                if (!Array.isArray(props.selected)) {
                     state.proxySelectedValue = [props.selected];
                 }
             }

--- a/src/inputs/input/type.ts
+++ b/src/inputs/input/type.ts
@@ -4,7 +4,7 @@ import type { MenuItem } from '@/inputs/context-menu/type';
 
 export interface SelectedItem {
     value: string;
-    label: string;
+    label?: string;
     invalid?: boolean;
     invalidText?: string | TranslateResult;
     duplicated?: boolean;


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [ ] Tested with console

### Description
`array` type added to PJsonSchemaForm (array type with `enum` is not ready yet!)

- Schema example
```typescript
{
  type: 'object',
  properties: {
    ...,
    emails: {
        description: 'Email addresses',
        title: 'Email Addresses',
        type: 'array',
        items: {
            type: 'string',
            minLength: 10,
            pattern: '^[\\W]*([\\w+\\-.%]+@[\\w\\-.]+\\.[A-Za-z]{2,4}[\\W]*,{1}[\\W]*)*([\\w+\\-.%]+@[\\w\\-.]+\\.[A-Za-z]{2,4})[\\W]*$',
        },
        examples: [
            'user1@test.com, user2@test.com',
        ],
        uniqueItems: true,
    },
  }
}
```

- with `uniqueItems` option
  To disallow duplicate values, you need to add the `uniqueItems` option in your schema. (중복값을 허용하지 않으려면 스키마에서 `uniqueItems` 옵션을 추가해야 합니다.)

  https://user-images.githubusercontent.com/18563857/197704764-c816e6fa-ef8d-44e7-b986-fa51b6c43878.mov

- with `minLength`, `pattern` option

  https://user-images.githubusercontent.com/18563857/197706536-1a0a8070-5fce-4f6b-8e47-4e9aee1b1538.mov