### PR TITLE
fix(query-search-dropdown): fix non-strict input issue on strict-mode

### DIFF
--- a/src/hooks/query-search/index.ts
+++ b/src/hooks/query-search/index.ts
@@ -262,10 +262,10 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
     // TODO: need to refactor
     const onKeyupEnter = async (): Promise<QueryItem | undefined> => {
         if (strict) {
-            if (state.rootKey) {
-                const res = find(state.handlerResp.results, (item: ValueMenuItem) => item.label === state.searchText || item.name === state.searchText);
-                if (res) return refineQueryItem(res);
-                return undefined;
+            const res = find(state.handlerResp.results, (item: ValueMenuItem) => item.label === state.searchText || item.name === state.searchText);
+            if (res) {
+                if (state.rootKey) return refineQueryItem(res);
+                await findAndSetKey(state.searchText);
             }
         } else if (state.currentDataType === 'object') {
             if (state.searchText) await findAndSetKey(state.searchText, false);
@@ -278,11 +278,10 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
                 return refineQueryItem({ label: 'Null', name: null });
             }
             return refineQueryItem({ label: state.searchText, name: state.searchText });
-        }
-
-        if (state.searchText) {
+        } else if (state.searchText) {
             return refineQueryItem({ label: state.searchText, name: state.searchText });
         }
+
         return undefined;
     };
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
- Strict mode is applied, but a non-existent value is entered.
- Fix wrong branch processing in `onKeyupEnter` `func`
  