### PR TITLE
refactor(context-menu-fixed-style-hook): refactor contextMenuFixedStyleHook

### DIFF
--- a/src/hooks/context-menu-fixed-style/index.ts
+++ b/src/hooks/context-menu-fixed-style/index.ts
@@ -79,8 +79,8 @@ export const useContextMenuFixedStyle = ({ useFixedMenuStyle, visibleMenu }: Sta
         contextMenuFixedStyleState.contextMenuStyle = contextMenuStyle;
     };
 
-    watch(() => visibleMenu.value, async () => {
-        if (!visibleMenu.value || !contextMenuFixedStyleState.targetRef) {
+    watch(() => state.visibleMenu, async () => {
+        if (!state.visibleMenu || !contextMenuFixedStyleState.targetRef) {
             contextMenuFixedStyleState.contextMenuStyle = {};
         }
 

--- a/src/hooks/context-menu-fixed-style/index.ts
+++ b/src/hooks/context-menu-fixed-style/index.ts
@@ -1,14 +1,12 @@
-import type { ComputedRef } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
 import {
-    computed, getCurrentInstance, onMounted, onUnmounted, reactive, toRefs, watch,
+    computed, nextTick, onMounted, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
 import type { Vue } from 'vue/types/vue';
 
 import type { ResizeObserverEntry } from '@juggle/resize-observer';
 import { ResizeObserver } from '@juggle/resize-observer';
 import { throttle } from 'lodash';
-
-import { makeOptionalProxy } from '@/util/composition-helpers';
 
 export interface ContextMenuFixedStyleProps {
     useFixedMenuStyle?: boolean;
@@ -17,7 +15,7 @@ export interface ContextMenuFixedStyleProps {
 
 interface StateArgs {
     useFixedMenuStyle?: ComputedRef<boolean|undefined> | boolean;
-    visibleMenu?: ComputedRef<boolean|undefined> | boolean;
+    visibleMenu: Ref<boolean>;
 }
 
 const isScrollable = (ele: Element) => {
@@ -35,20 +33,19 @@ const getScrollableParent = (ele?: Element|null): Element => {
 };
 
 export const useContextMenuFixedStyle = ({ useFixedMenuStyle, visibleMenu }: StateArgs) => {
-    const vm = getCurrentInstance()?.proxy as Vue;
     const state = reactive({
         useFixedMenuStyle,
         visibleMenu,
     });
+
     const contextMenuFixedStyleState = reactive({
-        proxyVisibleMenu: makeOptionalProxy('visibleMenu', vm, false),
         targetRef: null as Vue|Element|null,
         targetElement: computed<Element|null>(() => (contextMenuFixedStyleState.targetRef as Vue)?.$el ?? contextMenuFixedStyleState.targetRef),
         contextMenuStyle: {},
     });
 
     const hideMenu = throttle(() => {
-        if (contextMenuFixedStyleState.proxyVisibleMenu) contextMenuFixedStyleState.proxyVisibleMenu = false;
+        if (state.visibleMenu) state.visibleMenu = false;
     }, 300);
 
     const setStyleOfContextMenu = () => {
@@ -82,12 +79,12 @@ export const useContextMenuFixedStyle = ({ useFixedMenuStyle, visibleMenu }: Sta
         contextMenuFixedStyleState.contextMenuStyle = contextMenuStyle;
     };
 
-    watch(() => contextMenuFixedStyleState.proxyVisibleMenu, async () => {
-        if (!contextMenuFixedStyleState.proxyVisibleMenu || !contextMenuFixedStyleState.targetRef) {
+    watch(() => visibleMenu.value, async () => {
+        if (!visibleMenu.value || !contextMenuFixedStyleState.targetRef) {
             contextMenuFixedStyleState.contextMenuStyle = {};
         }
 
-        await vm.$nextTick(); // Needed codes for timing issues between painting DOM and proxyVisibleMenu
+        await nextTick(); // Needed codes for timing issues between painting DOM and visibleMenu
 
         setStyleOfContextMenu();
     }, { immediate: true });

--- a/src/inputs/dropdown/query-search-dropdown/type.ts
+++ b/src/inputs/dropdown/query-search-dropdown/type.ts
@@ -1,6 +1,7 @@
+import type { ContextMenuFixedStyleProps } from '@/hooks';
 import type { KeyItemSet, QueryItem, ValueHandlerMap } from '@/inputs/search/query-search/type';
 
-export interface QuerySearchDropdownProps {
+export interface QuerySearchDropdownProps extends ContextMenuFixedStyleProps {
     value: string;
     placeholder: string;
     focused: boolean;

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -5,13 +5,13 @@
              invalid,
              disabled,
              'read-only': readOnly,
-             active: proxyVisibleMenu && !readOnly,
+             active: visibleMenuRef && !readOnly,
          }"
     >
         <p-icon-button v-if="styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON"
                        ref="targetRef"
-                       :name="buttonIcon || (proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom')"
-                       :activated="proxyVisibleMenu"
+                       :name="buttonIcon || (visibleMenuRef ? 'ic_arrow_top' : 'ic_arrow_bottom')"
+                       :activated="visibleMenuRef"
                        :disabled="disabled"
                        color="inherit"
                        class="icon-button"
@@ -34,14 +34,14 @@
                 </slot>
             </span>
             <p-i v-if="!(styleType === SELECT_DROPDOWN_STYLE_TYPE.TRANSPARENT && readOnly)"
-                 :name="proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
-                 :activated="proxyVisibleMenu"
+                 :name="visibleMenuRef ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                 :activated="visibleMenuRef"
                  :disabled="disabled"
                  color="inherit"
                  class="dropdown-icon"
             />
         </button>
-        <p-context-menu v-show="proxyVisibleMenu"
+        <p-context-menu v-show="visibleMenuRef"
                         ref="contextMenuRef"
                         :class="{ [menuPosition]: !useFixedMenuStyle }"
                         :menu="items"
@@ -68,9 +68,9 @@ import {
     defineComponent,
     reactive,
     toRefs,
-    nextTick,
+    nextTick, ref,
 } from 'vue';
-import type { DirectiveFunction, SetupContext } from 'vue';
+import type { DirectiveFunction, SetupContext, Ref } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
 import { groupBy, reduce } from 'lodash';
@@ -163,14 +163,15 @@ export default defineComponent<SelectDropdownProps>({
         },
     },
     setup(props, { emit, slots }: SetupContext) {
+        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
         const {
-            proxyVisibleMenu, targetRef, targetElement, contextMenuStyle,
+            targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: computed(() => props.visibleMenu),
+            visibleMenu: visibleMenuRef,
         });
         const contextMenuFixedStyleState = reactive({
-            proxyVisibleMenu, targetRef, targetElement, contextMenuStyle,
+            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
         });
 
         const state = reactive({
@@ -208,18 +209,18 @@ export default defineComponent<SelectDropdownProps>({
                 emit('select', item.name, event);
                 state.proxySelected = item.name;
             }
-            contextMenuFixedStyleState.proxyVisibleMenu = false;
+            contextMenuFixedStyleState.visibleMenuRef = false;
         };
         const handleClick = (e: MouseEvent) => {
             if (props.readOnly || props.disabled) return;
-            contextMenuFixedStyleState.proxyVisibleMenu = !contextMenuFixedStyleState.proxyVisibleMenu;
+            contextMenuFixedStyleState.visibleMenuRef = !contextMenuFixedStyleState.visibleMenuRef;
             e.stopPropagation();
         };
         const handleClickOutside = (): void => {
-            contextMenuFixedStyleState.proxyVisibleMenu = false;
+            contextMenuFixedStyleState.visibleMenuRef = false;
         };
         const handlePressDownKey = () => {
-            if (!contextMenuFixedStyleState.proxyVisibleMenu) contextMenuFixedStyleState.proxyVisibleMenu = true;
+            if (!contextMenuFixedStyleState.visibleMenuRef) contextMenuFixedStyleState.visibleMenuRef = true;
             nextTick(() => {
                 if (state.contextMenuRef) {
                     if (slots['menu-menu']) emit('focus-menu');

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -66,7 +66,7 @@
                 <slot name="right-edge" v-bind="{ value }" />
             </span>
         </div>
-        <p-context-menu v-if="proxyVisibleMenu && useAutoComplete"
+        <p-context-menu v-if="visibleMenuRef && useAutoComplete"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :highlight-term="proxyValue"
@@ -79,9 +79,9 @@
 </template>
 
 <script lang="ts">
-import type { PropType } from 'vue';
+import type { PropType, Ref } from 'vue';
 import {
-    computed, defineComponent, reactive, toRefs, watch,
+    computed, defineComponent, reactive, ref, toRefs, watch,
 } from 'vue';
 
 import vClickOutside from 'v-click-outside';
@@ -208,14 +208,15 @@ export default defineComponent<TextInputProps>({
     },
 
     setup(props, { emit, listeners, attrs }) {
+        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
         const {
-            proxyVisibleMenu, targetRef, targetElement, contextMenuStyle,
+            targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: computed(() => props.visibleMenu),
+            visibleMenu: visibleMenuRef,
         });
         const contextMenuFixedStyleState = reactive({
-            proxyVisibleMenu, targetRef, targetElement, contextMenuStyle,
+            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
         });
 
         const state = reactive({
@@ -256,12 +257,12 @@ export default defineComponent<TextInputProps>({
         };
 
         const hideMenu = () => {
-            contextMenuFixedStyleState.proxyVisibleMenu = false;
+            contextMenuFixedStyleState.visibleMenuRef = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            contextMenuFixedStyleState.proxyVisibleMenu = true;
+            contextMenuFixedStyleState.visibleMenuRef = true;
             emit('show-menu');
         };
 

--- a/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
+++ b/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
@@ -13,7 +13,7 @@
                 <slot :name="`search-${slot}`" v-bind="{...scope}" />
             </template>
         </p-search>
-        <p-context-menu v-if="proxyVisibleMenu"
+        <p-context-menu v-if="visibleMenuRef"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :loading="loading"
@@ -33,8 +33,9 @@
 
 <script lang="ts">
 import {
-    computed, defineComponent, getCurrentInstance, onMounted, onUnmounted, reactive, toRefs, watch,
+    computed, defineComponent, getCurrentInstance, onMounted, onUnmounted, reactive, ref, toRefs, watch,
 } from 'vue';
+import type { Ref } from 'vue';
 import type { Vue } from 'vue/types/vue';
 
 import Fuse from 'fuse.js';
@@ -142,15 +143,16 @@ export default defineComponent<AutocompleteSearchProps>({
     },
     setup(props: AutocompleteSearchProps, { emit, slots, listeners }) {
         const vm = getCurrentInstance()?.proxy as Vue;
+        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
 
         const {
-            proxyVisibleMenu, targetRef, targetElement, contextMenuStyle,
+            targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: computed(() => props.visibleMenu),
+            visibleMenu: visibleMenuRef,
         });
         const contextMenuFixedStyleState = reactive({
-            proxyVisibleMenu, targetRef, targetElement, contextMenuStyle,
+            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
         });
 
         const state = reactive({
@@ -219,12 +221,12 @@ export default defineComponent<AutocompleteSearchProps>({
         };
 
         const hideMenu = () => {
-            if (state.isAutoMode) contextMenuFixedStyleState.proxyVisibleMenu = false;
+            if (state.isAutoMode) contextMenuFixedStyleState.visibleMenuRef = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            if (state.isAutoMode) contextMenuFixedStyleState.proxyVisibleMenu = true;
+            if (state.isAutoMode) contextMenuFixedStyleState.visibleMenuRef = true;
             emit('show-menu');
         };
 
@@ -241,7 +243,7 @@ export default defineComponent<AutocompleteSearchProps>({
         };
 
         const onWindowKeydown = (e: KeyboardEvent) => {
-            if (contextMenuFixedStyleState.proxyVisibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
+            if (contextMenuFixedStyleState.visibleMenuRef && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
                 e.preventDefault();
             }
         };
@@ -276,7 +278,7 @@ export default defineComponent<AutocompleteSearchProps>({
         }, {}));
 
         const onInput = (val: string, e) => {
-            if (!contextMenuFixedStyleState.proxyVisibleMenu) showMenu();
+            if (!contextMenuFixedStyleState.visibleMenuRef) showMenu();
 
             state.proxyValue = val;
             emit('input', val, e);


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
- Renewal `useContextMenuFixedHook`.
- ProxyVisibleMenu state managed in the hook is delegated externally.
- VisibleMenu Props change from just `boolean` to `Ref<boolean>`.
- Remove `getCurrentInstance()`.
- Apply to all components that have dependencies
- `PSearchDropdown` / `PSelectDropdown` / `PTextInput` / `PAutocompleteSearch` / `PQuerySearchDropdown`

---

- `useContextMenuFixedHook`을 리팩토링 했습니다.
- 훅 안에서 양방향으로 관리되던 ProxyVisibleMenu state를 외부로 위임했습니다.
- VisibleMenu 프롭이 `boolean`에서 `Ref<boolean>`으로 변경되었습니다.
- `getCurrentIntance()` 가 제거되었습니다.
- 훅에 의존성을 갖고 있는 모든 컴포넌트에 적용되었습니다.
- `PSearchDropdown` / `PSelectDropdown` / `PTextInput` / `PAutocompleteSearch` / `PQuerySearchDropdown`

