### PR TITLE
refactor(query-search-hook): refactor query-search-hook & fix query-search-dropdown fixed issue

### DIFF
--- a/src/hooks/context-menu-fixed-style/index.ts
+++ b/src/hooks/context-menu-fixed-style/index.ts
@@ -15,7 +15,7 @@ export interface ContextMenuFixedStyleProps {
 
 interface StateArgs {
     useFixedMenuStyle?: ComputedRef<boolean|undefined> | boolean;
-    visibleMenu: Ref<boolean>;
+    visibleMenu: Ref<boolean | undefined>;
 }
 
 const isScrollable = (ele: Element) => {

--- a/src/hooks/query-search/index.ts
+++ b/src/hooks/query-search/index.ts
@@ -36,7 +36,7 @@ export interface QuerySearchStateArgs {
     value?: Ref<string>;
     keyItemSets: Ref<KeyItemSet[]>;
     valueHandlerMap: Ref<ValueHandlerMap>;
-    visibleMenu: Ref<boolean>;
+    visibleMenu: Ref<boolean | undefined>;
 }
 
 export const useQuerySearch = (stateArgs: QuerySearchStateArgs, options: QuerySearchOptions = {}) => {

--- a/src/hooks/query-search/index.ts
+++ b/src/hooks/query-search/index.ts
@@ -18,10 +18,10 @@ import {
     findKey, getKeyMenuForm, getRootKeyItemHandler, getValueMenuForm,
 } from '@/inputs/search/query-search/helper';
 import type {
-    KeyItem, OperatorType, KeyDataType, QuerySearchProps,
+    KeyItem, OperatorType, KeyDataType,
     HandlerResponse, MenuType, ValueHandler,
     KeyMenuItem, ValueMenuItem,
-    QueryItem, ValueItem,
+    QueryItem, ValueItem, QuerySearchStateArgs,
 } from '@/inputs/search/query-search/type';
 import { OPERATOR, operators } from '@/inputs/search/query-search/type';
 
@@ -31,13 +31,21 @@ interface QuerySearchOptions {
     strict?: boolean;
 }
 
-export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOptions = {}) => {
+
+export const useQuerySearch = (stateArgs: QuerySearchStateArgs, options: QuerySearchOptions = {}) => {
+    const {
+        focused, value, visibleMenu, valueHandlerMap, keyItemSets,
+    } = stateArgs;
     const { strict } = options;
     const state = reactive({
+        /* Args */
+        keyItemSets,
+        valueHandlerMap,
+
         /* Input */
+        isFocused: focused,
+        searchText: value,
         inputRef: null as null|HTMLElement,
-        isFocused: props.focused,
-        searchText: props.value,
         currentPlaceholder: computed(() => placeholderMap[state.currentDataType] || undefined),
         inputElType: computed(() => inputTypeMap[state.currentDataType] || 'text'),
         currentDataType: computed<KeyDataType|string>(() => {
@@ -61,7 +69,7 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
 
         /* Menu */
         menuRef: null as any,
-        visibleMenu: false,
+        visibleMenu,
         menuType: computed<MenuType>(() => {
             if (!state.rootKey) return 'ROOT_KEY';
             if (state.currentDataType === 'object') return 'KEY';
@@ -73,9 +81,9 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
         loading: false,
         lazyLoading: false,
         handler: computed<ValueHandler|null>(() => {
-            if (state.menuType === 'ROOT_KEY') return getRootKeyItemHandler(props.keyItemSets);
+            if (state.menuType === 'ROOT_KEY') return getRootKeyItemHandler(state.keyItemSets);
             return defaultHandlerMap[state.currentDataType]
-                || props.valueHandlerMap[state.rootKey?.name as string]
+                || state.valueHandlerMap[state.rootKey?.name as string]
                 || null;
         }),
         handlerResp: { results: [] } as HandlerResponse,
@@ -146,9 +154,9 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
     const updateLoader = debounce(() => {
         state.lazyLoading = state.loading;
     }, 500);
-    const updateLoading = (value, force = false) => {
-        state.loading = value;
-        if (force) state.lazyLoading = value;
+    const updateLoading = (loading, force = false) => {
+        state.loading = loading;
+        if (force) state.lazyLoading = loading;
         else if (state.lazyLoading !== state.loading) updateLoader();
     };
 
@@ -199,7 +207,7 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
 
     /* Utils */
     const getKeyItemsFromKeyText = (keyStr: string): KeyItem[] => {
-        const allKeyItems = props.keyItemSets.map(d => d.items).flat();
+        const allKeyItems = state.keyItemSets.map(d => d.items).flat();
         const dotIdx = keyStr.indexOf('.');
         let keyItems: KeyItem[] = [];
 
@@ -337,10 +345,10 @@ export const useQuerySearch = (props: QuerySearchProps, options: QuerySearchOpti
             const keyStr = text.slice(0, separatorIdx);
             const keyItems = getKeyItemsFromKeyText(keyStr);
 
-            const value = text.slice(separatorIdx + 1);
+            const textValue = text.slice(separatorIdx + 1);
             if (keyItems.length > 0) {
                 state.selectedKeys = keyItems;
-                state.searchText = value;
+                state.searchText = textValue;
                 hideMenu();
             } else {
                 state.searchText = text;

--- a/src/hooks/query-search/index.ts
+++ b/src/hooks/query-search/index.ts
@@ -1,6 +1,6 @@
-import type { WatchStopHandle } from 'vue';
+import type { WatchStopHandle, Ref } from 'vue';
 import {
-    computed, onMounted, onUnmounted, reactive, watch,
+    computed, onMounted, onUnmounted, reactive, ref, watch,
 } from 'vue';
 
 import {
@@ -17,13 +17,13 @@ import {
 import {
     findKey, getKeyMenuForm, getRootKeyItemHandler, getValueMenuForm,
 } from '@/inputs/search/query-search/helper';
+import { OPERATOR, operators } from '@/inputs/search/query-search/type';
 import type {
     KeyItem, OperatorType, KeyDataType,
     HandlerResponse, MenuType, ValueHandler,
     KeyMenuItem, ValueMenuItem,
-    QueryItem, ValueItem, QuerySearchStateArgs,
+    QueryItem, ValueItem, KeyItemSet, ValueHandlerMap,
 } from '@/inputs/search/query-search/type';
-import { OPERATOR, operators } from '@/inputs/search/query-search/type';
 
 const ROOT_KEY_SETTER = ':';
 const NUMBER_TYPES = ['integer', 'float'];
@@ -31,10 +31,17 @@ interface QuerySearchOptions {
     strict?: boolean;
 }
 
+export interface QuerySearchStateArgs {
+    focused: boolean;
+    value?: Ref<string>;
+    keyItemSets: Ref<KeyItemSet[]>;
+    valueHandlerMap: Ref<ValueHandlerMap>;
+    visibleMenu: Ref<boolean>;
+}
 
 export const useQuerySearch = (stateArgs: QuerySearchStateArgs, options: QuerySearchOptions = {}) => {
     const {
-        focused, value, visibleMenu, valueHandlerMap, keyItemSets,
+        value, focused, visibleMenu, valueHandlerMap, keyItemSets,
     } = stateArgs;
     const { strict } = options;
     const state = reactive({
@@ -44,7 +51,7 @@ export const useQuerySearch = (stateArgs: QuerySearchStateArgs, options: QuerySe
 
         /* Input */
         isFocused: focused,
-        searchText: value,
+        searchText: value || ref(''),
         inputRef: null as null|HTMLElement,
         currentPlaceholder: computed(() => placeholderMap[state.currentDataType] || undefined),
         inputElType: computed(() => inputTypeMap[state.currentDataType] || 'text'),

--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.stories.mdx
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.stories.mdx
@@ -105,6 +105,36 @@ Query Search Dropdown is <b>```key:value``` format search dropdown.</b> <br/>
 <br/>
 <br/>
 
+## Use Fixed Menu Style
+<Canvas>
+    <Story name="Use Fixed Menu Style">
+        {{
+            components: { PQuerySearchDropdown },
+            template: `
+<div class="h-full w-full overflow p-8">
+    <p-query-search-dropdown
+        :key-item-sets="keyItemSets"
+        :value-handler-map="valueHandlerMap"
+        use-fixed-menu-style
+        multi-selectable
+    ></p-query-search-dropdown>
+</div>
+    `,
+            setup() {
+                const keyItemSets = getKeyItemSets(5, 1)
+                const valueHandlerMap = getValueHandlerMap(keyItemSets)
+                return {
+                    keyItemSets,
+                    valueHandlerMap
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
 ## Playground
 
 <Canvas>

--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
@@ -49,19 +49,18 @@
                 </div>
             </template>
         </p-search>
-        <div v-show="visibleMenuRef" class="menu-container">
-            <p-context-menu ref="menuRef"
-                            :loading="querySearchState.lazyLoading"
-                            :menu="querySearchState.menu"
-                            :highlight-term="querySearchState.searchText"
-                            :style="{...contextMenuStyle, maxWidth: contextMenuStyle.minWidth, width: contextMenuStyle.minWidth}"
-                            no-select-indication
-                            @keyup:up:end="focus"
-                            @keyup:down:end="focus"
-                            @select="onMenuSelect"
-                            @blur="focus"
-            />
-        </div>
+        <p-context-menu v-show="visibleMenuRef"
+                        ref="menuRef"
+                        :loading="querySearchState.lazyLoading"
+                        :menu="querySearchState.menu"
+                        :highlight-term="querySearchState.searchText"
+                        :style="{...contextMenuStyle, maxWidth: contextMenuStyle.minWidth, width: contextMenuStyle.minWidth}"
+                        no-select-indication
+                        @keyup:up:end="focus"
+                        @keyup:down:end="focus"
+                        @select="onMenuSelect"
+                        @blur="focus"
+        />
     </div>
 </template>
 
@@ -167,7 +166,16 @@ export default defineComponent<QuerySearchDropdownProps>({
             onPaste,
             onDeleteAll,
             preTreatSelectedMenuItem,
-        } = useQuerySearch(props, { strict: true });
+        } = useQuerySearch(
+            {
+                value: props.value,
+                focused: props.focused,
+                valueHandlerMap: computed(() => props.valueHandlerMap),
+                keyItemSets: computed(() => props.keyItemSets),
+                visibleMenu: visibleMenuRef,
+            },
+            { strict: true },
+        );
 
 
         /* util */
@@ -223,13 +231,10 @@ export default defineComponent<QuerySearchDropdownProps>({
 
 <style lang="postcss">
 .p-query-search-dropdown {
-    @apply w-full;
+    @apply w-full relative;
     .p-search {
         @apply text-sm font-normal;
         padding: 0.25rem 0.5rem;
-    }
-    .menu-container {
-        @apply w-full relative;
     }
     .input-set {
         display: inline-flex;

--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
@@ -113,7 +113,7 @@ export default defineComponent<QuerySearchDropdownProps>({
         },
         visibleMenu: {
             type: Boolean,
-            default: false,
+            default: undefined,
         },
         useFixedMenuStyle: {
             type: Boolean,
@@ -140,7 +140,7 @@ export default defineComponent<QuerySearchDropdownProps>({
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxySelected: useProxyValue('selected', props, emit),
-            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
+            proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
         });
 
         const {

--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
@@ -42,14 +42,14 @@
                         />
                     </span>
                     <span class="dropdown-button" :class="{'text-blue-600': querySearchState.isFocused}" @click="handleClickDropdownButton">
-                        <p-i class="icon" :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                        <p-i class="icon" :name="proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
                              color="inherit"
                         />
                     </span>
                 </div>
             </template>
         </p-search>
-        <p-context-menu v-show="visibleMenu"
+        <p-context-menu v-show="proxyVisibleMenu"
                         ref="menuRef"
                         :loading="querySearchState.lazyLoading"
                         :menu="querySearchState.menu"
@@ -69,7 +69,7 @@ import type {
     PropType, DirectiveFunction, SetupContext,
 } from 'vue';
 import {
-    computed, ref,
+    computed,
     defineComponent, reactive, toRefs, toRef,
 } from 'vue';
 
@@ -140,14 +140,14 @@ export default defineComponent<QuerySearchDropdownProps>({
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxySelected: useProxyValue('selected', props, emit),
-            visibleMenu: ref(props.visibleMenu || false),
+            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
         });
 
         const {
             targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: toRef(state, 'visibleMenu'),
+            visibleMenu: toRef(state, 'proxyVisibleMenu'),
         });
         const contextMenuFixedStyleState = reactive({
             targetRef, targetElement, contextMenuStyle,
@@ -167,7 +167,7 @@ export default defineComponent<QuerySearchDropdownProps>({
                 focused: props.focused,
                 valueHandlerMap: toRef(props, 'valueHandlerMap'),
                 keyItemSets: toRef(props, 'keyItemSets'),
-                visibleMenu: toRef(state, 'visibleMenu'),
+                visibleMenu: toRef(state, 'proxyVisibleMenu'),
             },
             { strict: true },
         );
@@ -199,7 +199,7 @@ export default defineComponent<QuerySearchDropdownProps>({
         };
 
         const handleClickDropdownButton = () => {
-            if (state.visibleMenu) hideMenu();
+            if (state.proxyVisibleMenu) hideMenu();
             else showMenu(true);
         };
 

--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
@@ -42,14 +42,14 @@
                         />
                     </span>
                     <span class="dropdown-button" :class="{'text-blue-600': querySearchState.isFocused}" @click="handleClickDropdownButton">
-                        <p-i class="icon" :name="visibleMenuRef ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                        <p-i class="icon" :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
                              color="inherit"
                         />
                     </span>
                 </div>
             </template>
         </p-search>
-        <p-context-menu v-show="visibleMenuRef"
+        <p-context-menu v-show="visibleMenu"
                         ref="menuRef"
                         :loading="querySearchState.lazyLoading"
                         :menu="querySearchState.menu"
@@ -66,11 +66,11 @@
 
 <script lang="ts">
 import type {
-    PropType, DirectiveFunction, SetupContext, Ref,
+    PropType, DirectiveFunction, SetupContext,
 } from 'vue';
 import {
     computed, ref,
-    defineComponent, reactive, toRefs,
+    defineComponent, reactive, toRefs, toRef,
 } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
@@ -103,10 +103,6 @@ export default defineComponent<QuerySearchDropdownProps>({
         event: 'update:value',
     },
     props: {
-        value: {
-            type: String,
-            default: '',
-        },
         placeholder: {
             type: String,
             default: undefined,
@@ -144,17 +140,17 @@ export default defineComponent<QuerySearchDropdownProps>({
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             proxySelected: useProxyValue('selected', props, emit),
+            visibleMenu: ref(props.visibleMenu || false),
         });
-        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
 
         const {
             targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: visibleMenuRef,
+            visibleMenu: toRef(state, 'visibleMenu'),
         });
         const contextMenuFixedStyleState = reactive({
-            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
+            targetRef, targetElement, contextMenuStyle,
         });
 
         const {
@@ -168,11 +164,10 @@ export default defineComponent<QuerySearchDropdownProps>({
             preTreatSelectedMenuItem,
         } = useQuerySearch(
             {
-                value: props.value,
                 focused: props.focused,
-                valueHandlerMap: computed(() => props.valueHandlerMap),
-                keyItemSets: computed(() => props.keyItemSets),
-                visibleMenu: visibleMenuRef,
+                valueHandlerMap: toRef(props, 'valueHandlerMap'),
+                keyItemSets: toRef(props, 'keyItemSets'),
+                visibleMenu: toRef(state, 'visibleMenu'),
             },
             { strict: true },
         );
@@ -204,7 +199,7 @@ export default defineComponent<QuerySearchDropdownProps>({
         };
 
         const handleClickDropdownButton = () => {
-            if (querySearchState.visibleMenu) hideMenu();
+            if (state.visibleMenu) hideMenu();
             else showMenu(true);
         };
 

--- a/src/inputs/dropdown/query-search-dropdown/story-helper.ts
+++ b/src/inputs/dropdown/query-search-dropdown/story-helper.ts
@@ -108,5 +108,42 @@ export const getQuerySearchDropdownArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
+        // context menu fixed style props
+        useFixedMenuStyle: {
+            name: 'useFixedMenuStyle',
+            type: { name: 'boolean' },
+            description: 'Whether to use position fixed style on menu or not. ',
+            defaultValue: false,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'false',
+                },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        visibleMenu: {
+            name: 'visibleMenu',
+            type: { name: 'boolean' },
+            description: 'Whether to show the menu or not. Automatically determined if no value is given. `sync` props.',
+            defaultValue: undefined,
+            table: {
+                type: {
+                    summary: 'boolean',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'undefined',
+                },
+            },
+            control: {
+                type: null,
+            },
+        },
     };
 };

--- a/src/inputs/dropdown/query-search-dropdown/story-helper.ts
+++ b/src/inputs/dropdown/query-search-dropdown/story-helper.ts
@@ -1,13 +1,10 @@
 import type { ArgTypes } from '@storybook/addons';
 
 import { getKeyItemSets, getValueHandlerMap } from '@/inputs/dropdown/query-search-dropdown/mock';
-import { getSearchArgTypes } from '@/inputs/search/search/story-helper';
 
 export const getQuerySearchDropdownArgTypes = (): ArgTypes => {
-    const searchArgTypes = getSearchArgTypes();
     const keyItemSets = getKeyItemSets(5, 1);
     return {
-        value: searchArgTypes.value,
         placeholder: {
             name: 'placeholder',
             type: { name: 'string' },
@@ -23,7 +20,6 @@ export const getQuerySearchDropdownArgTypes = (): ArgTypes => {
                 },
             },
         },
-        'v-model': searchArgTypes['v-model'],
         focused: {
             name: 'focused',
             type: { name: 'boolean' },

--- a/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
+++ b/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
@@ -14,7 +14,7 @@
         >
             <div v-if="searchDropdownType === SEARCH_DROPDOWN_TYPE.radioButton &&
                      proxySelected.length &&
-                     !visibleMenuRef &&
+                     !visibleMenu &&
                      !proxyIsFocused"
                  class="selected-radio-label"
             >
@@ -36,8 +36,8 @@
                      @click="onDeleteAllTags"
                 />
             </template>
-            <template v-if="searchDropdownType !== SEARCH_DROPDOWN_TYPE.default || !proxySelected.length || visibleMenuRef" #right>
-                <p-i :name="visibleMenuRef ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+            <template v-if="searchDropdownType !== SEARCH_DROPDOWN_TYPE.default || !proxySelected.length || visibleMenu" #right>
+                <p-i :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
                      color="inherit" class="dropdown-button" :class="disabled"
                      @click.stop="handleClickDropdownButton"
                 />
@@ -46,7 +46,7 @@
                 <slot :name="`search-${slot}`" v-bind="{...scope}" />
             </template>
         </p-search>
-        <p-context-menu v-show="visibleMenuRef"
+        <p-context-menu v-show="visibleMenu"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :loading="loading"
@@ -81,10 +81,10 @@
 
 <script lang="ts">
 import {
-    computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch, nextTick, ref,
+    computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch, nextTick, ref, toRef,
 } from 'vue';
 import type Vue from 'vue';
-import type { DirectiveFunction, SetupContext, Ref } from 'vue';
+import type { DirectiveFunction, SetupContext } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
 import { reduce } from 'lodash';
@@ -195,18 +195,8 @@ export default defineComponent<SearchDropdownProps>({
         },
     },
     setup(props, { emit, slots, listeners }: SetupContext) {
-        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
-        const {
-            targetRef, targetElement, contextMenuStyle,
-        } = useContextMenuFixedStyle({
-            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: visibleMenuRef,
-        });
-        const contextMenuFixedStyleState = reactive({
-            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
-        });
-
         const state = reactive({
+            visibleMenu: ref(props.visibleMenu || false),
             menuRef: null as null|Vue,
             searchDropdownType: computed<SEARCH_DROPDOWN_TYPE | undefined>(() => {
                 if (props.type) return props.type;
@@ -231,6 +221,16 @@ export default defineComponent<SearchDropdownProps>({
                 if (name.startsWith('search-')) res[`${name.substring(7)}`] = d;
                 return res;
             }, {})),
+        });
+
+        const {
+            targetRef, targetElement, contextMenuStyle,
+        } = useContextMenuFixedStyle({
+            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
+            visibleMenu: toRef(state, 'visibleMenu'),
+        });
+        const contextMenuFixedStyleState = reactive({
+            targetRef, targetElement, contextMenuStyle,
         });
 
         const defaultHandler = (inputText: string, list: SearchDropdownMenuItem[]) => {
@@ -276,7 +276,7 @@ export default defineComponent<SearchDropdownProps>({
         };
 
         const hideMenu = (mode?: string) => {
-            if (!contextMenuFixedStyleState.visibleMenuRef) return;
+            if (!state.visibleMenu) return;
             // placeholder
             const isRadioItemSelected = state.searchDropdownType === SEARCH_DROPDOWN_TYPE.radioButton && (mode === 'click' || state.proxySelected.length);
             if (isRadioItemSelected) {
@@ -298,12 +298,12 @@ export default defineComponent<SearchDropdownProps>({
                 state.proxyValue = '';
             }
 
-            contextMenuFixedStyleState.visibleMenuRef = false;
+            state.visibleMenu = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            if (contextMenuFixedStyleState.visibleMenuRef) return;
+            if (state.visibleMenu) return;
 
             if (
                 state.proxySelected.length && (
@@ -320,7 +320,7 @@ export default defineComponent<SearchDropdownProps>({
                 filterMenu(state.proxyValue);
             }
 
-            contextMenuFixedStyleState.visibleMenuRef = true;
+            state.visibleMenu = true;
             emit('show-menu');
         };
 
@@ -371,7 +371,7 @@ export default defineComponent<SearchDropdownProps>({
         };
 
         const onInput = (val: string, e) => {
-            if (!contextMenuFixedStyleState.visibleMenuRef) showMenu();
+            if (!state.visibleMenu) showMenu();
 
             state.proxyValue = val;
             emit('input', val, e);
@@ -425,7 +425,7 @@ export default defineComponent<SearchDropdownProps>({
 
         const handleClickDropdownButton = () => {
             if (props.disabled) return;
-            if (contextMenuFixedStyleState.visibleMenuRef) hideMenu();
+            if (state.visibleMenu) hideMenu();
             else showMenu();
         };
 
@@ -456,7 +456,7 @@ export default defineComponent<SearchDropdownProps>({
         };
 
         const onWindowKeydown = (e: KeyboardEvent) => {
-            if (contextMenuFixedStyleState.visibleMenuRef && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
+            if (state.visibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
                 e.preventDefault();
             }
         };

--- a/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
+++ b/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
@@ -14,7 +14,7 @@
         >
             <div v-if="searchDropdownType === SEARCH_DROPDOWN_TYPE.radioButton &&
                      proxySelected.length &&
-                     !visibleMenu &&
+                     !proxyVisibleMenu &&
                      !proxyIsFocused"
                  class="selected-radio-label"
             >
@@ -37,7 +37,7 @@
                 />
             </template>
             <template v-if="searchDropdownType !== SEARCH_DROPDOWN_TYPE.default || !proxySelected.length || visibleMenu" #right>
-                <p-i :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                <p-i :name="proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
                      color="inherit" class="dropdown-button" :class="disabled"
                      @click.stop="handleClickDropdownButton"
                 />
@@ -46,7 +46,7 @@
                 <slot :name="`search-${slot}`" v-bind="{...scope}" />
             </template>
         </p-search>
-        <p-context-menu v-show="visibleMenu"
+        <p-context-menu v-show="proxyVisibleMenu"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :loading="loading"
@@ -81,7 +81,7 @@
 
 <script lang="ts">
 import {
-    computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch, nextTick, ref, toRef,
+    computed, defineComponent, onMounted, onUnmounted, reactive, toRefs, watch, nextTick, toRef,
 } from 'vue';
 import type Vue from 'vue';
 import type { DirectiveFunction, SetupContext } from 'vue';
@@ -196,7 +196,7 @@ export default defineComponent<SearchDropdownProps>({
     },
     setup(props, { emit, slots, listeners }: SetupContext) {
         const state = reactive({
-            visibleMenu: ref(props.visibleMenu || false),
+            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
             menuRef: null as null|Vue,
             searchDropdownType: computed<SEARCH_DROPDOWN_TYPE | undefined>(() => {
                 if (props.type) return props.type;
@@ -227,7 +227,7 @@ export default defineComponent<SearchDropdownProps>({
             targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: toRef(state, 'visibleMenu'),
+            visibleMenu: toRef(state, 'proxyVisibleMenu'),
         });
         const contextMenuFixedStyleState = reactive({
             targetRef, targetElement, contextMenuStyle,
@@ -276,7 +276,7 @@ export default defineComponent<SearchDropdownProps>({
         };
 
         const hideMenu = (mode?: string) => {
-            if (!state.visibleMenu) return;
+            if (!state.proxyVisibleMenu) return;
             // placeholder
             const isRadioItemSelected = state.searchDropdownType === SEARCH_DROPDOWN_TYPE.radioButton && (mode === 'click' || state.proxySelected.length);
             if (isRadioItemSelected) {
@@ -298,12 +298,12 @@ export default defineComponent<SearchDropdownProps>({
                 state.proxyValue = '';
             }
 
-            state.visibleMenu = false;
+            state.proxyVisibleMenu = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            if (state.visibleMenu) return;
+            if (state.proxyVisibleMenu) return;
 
             if (
                 state.proxySelected.length && (
@@ -320,7 +320,7 @@ export default defineComponent<SearchDropdownProps>({
                 filterMenu(state.proxyValue);
             }
 
-            state.visibleMenu = true;
+            state.proxyVisibleMenu = true;
             emit('show-menu');
         };
 
@@ -371,7 +371,7 @@ export default defineComponent<SearchDropdownProps>({
         };
 
         const onInput = (val: string, e) => {
-            if (!state.visibleMenu) showMenu();
+            if (!state.proxyVisibleMenu) showMenu();
 
             state.proxyValue = val;
             emit('input', val, e);
@@ -425,7 +425,7 @@ export default defineComponent<SearchDropdownProps>({
 
         const handleClickDropdownButton = () => {
             if (props.disabled) return;
-            if (state.visibleMenu) hideMenu();
+            if (state.proxyVisibleMenu) hideMenu();
             else showMenu();
         };
 
@@ -456,7 +456,7 @@ export default defineComponent<SearchDropdownProps>({
         };
 
         const onWindowKeydown = (e: KeyboardEvent) => {
-            if (state.visibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
+            if (state.proxyVisibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
                 e.preventDefault();
             }
         };

--- a/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
+++ b/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
@@ -196,7 +196,7 @@ export default defineComponent<SearchDropdownProps>({
     },
     setup(props, { emit, slots, listeners }: SetupContext) {
         const state = reactive({
-            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
+            proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
             menuRef: null as null|Vue,
             searchDropdownType: computed<SEARCH_DROPDOWN_TYPE | undefined>(() => {
                 if (props.type) return props.type;

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -5,13 +5,13 @@
              invalid,
              disabled,
              'read-only': readOnly,
-             active: visibleMenu && !readOnly,
+             active: proxyVisibleMenu && !readOnly,
          }"
     >
         <p-icon-button v-if="styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON"
                        ref="targetRef"
-                       :name="buttonIcon || (visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom')"
-                       :activated="visibleMenu"
+                       :name="buttonIcon || (proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom')"
+                       :activated="proxyVisibleMenu"
                        :disabled="disabled"
                        color="inherit"
                        class="icon-button"
@@ -34,14 +34,14 @@
                 </slot>
             </span>
             <p-i v-if="!(styleType === SELECT_DROPDOWN_STYLE_TYPE.TRANSPARENT && readOnly)"
-                 :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
-                 :activated="visibleMenu"
+                 :name="proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                 :activated="proxyVisibleMenu"
                  :disabled="disabled"
                  color="inherit"
                  class="dropdown-icon"
             />
         </button>
-        <p-context-menu v-show="visibleMenu"
+        <p-context-menu v-show="proxyVisibleMenu"
                         ref="contextMenuRef"
                         :class="{ [menuPosition]: !useFixedMenuStyle }"
                         :menu="items"
@@ -68,7 +68,7 @@ import {
     defineComponent,
     reactive,
     toRefs,
-    nextTick, ref, toRef,
+    nextTick, toRef,
 } from 'vue';
 import type { DirectiveFunction, SetupContext } from 'vue';
 
@@ -164,7 +164,7 @@ export default defineComponent<SelectDropdownProps>({
     },
     setup(props, { emit, slots }: SetupContext) {
         const state = reactive({
-            visibleMenu: ref(props.visibleMenu || false),
+            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
             contextMenuRef: null as null|any,
             proxySelected: useProxyValue('selected', props, emit),
             selectedItem: computed<MenuItem|null>(() => {
@@ -193,7 +193,7 @@ export default defineComponent<SelectDropdownProps>({
             targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: toRef(state, 'visibleMenu'),
+            visibleMenu: toRef(state, 'proxyVisibleMenu'),
         });
         const contextMenuFixedStyleState = reactive({
             targetRef, targetElement, contextMenuStyle,
@@ -208,18 +208,18 @@ export default defineComponent<SelectDropdownProps>({
                 emit('select', item.name, event);
                 state.proxySelected = item.name;
             }
-            state.visibleMenu = false;
+            state.proxyVisibleMenu = false;
         };
         const handleClick = (e: MouseEvent) => {
             if (props.readOnly || props.disabled) return;
-            state.visibleMenu = !state.visibleMenu;
+            state.proxyVisibleMenu = !state.proxyVisibleMenu;
             e.stopPropagation();
         };
         const handleClickOutside = (): void => {
             state.visibleMenu = false;
         };
         const handlePressDownKey = () => {
-            if (!state.visibleMenu) state.visibleMenu = true;
+            if (!state.proxyVisibleMenu) state.proxyVisibleMenu = true;
             nextTick(() => {
                 if (state.contextMenuRef) {
                     if (slots['menu-menu']) emit('focus-menu');

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -164,7 +164,7 @@ export default defineComponent<SelectDropdownProps>({
     },
     setup(props, { emit, slots }: SetupContext) {
         const state = reactive({
-            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
+            proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
             contextMenuRef: null as null|any,
             proxySelected: useProxyValue('selected', props, emit),
             selectedItem: computed<MenuItem|null>(() => {

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -5,13 +5,13 @@
              invalid,
              disabled,
              'read-only': readOnly,
-             active: visibleMenuRef && !readOnly,
+             active: visibleMenu && !readOnly,
          }"
     >
         <p-icon-button v-if="styleType === SELECT_DROPDOWN_STYLE_TYPE.ICON_BUTTON"
                        ref="targetRef"
-                       :name="buttonIcon || (visibleMenuRef ? 'ic_arrow_top' : 'ic_arrow_bottom')"
-                       :activated="visibleMenuRef"
+                       :name="buttonIcon || (visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom')"
+                       :activated="visibleMenu"
                        :disabled="disabled"
                        color="inherit"
                        class="icon-button"
@@ -34,14 +34,14 @@
                 </slot>
             </span>
             <p-i v-if="!(styleType === SELECT_DROPDOWN_STYLE_TYPE.TRANSPARENT && readOnly)"
-                 :name="visibleMenuRef ? 'ic_arrow_top' : 'ic_arrow_bottom'"
-                 :activated="visibleMenuRef"
+                 :name="visibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                 :activated="visibleMenu"
                  :disabled="disabled"
                  color="inherit"
                  class="dropdown-icon"
             />
         </button>
-        <p-context-menu v-show="visibleMenuRef"
+        <p-context-menu v-show="visibleMenu"
                         ref="contextMenuRef"
                         :class="{ [menuPosition]: !useFixedMenuStyle }"
                         :menu="items"
@@ -68,9 +68,9 @@ import {
     defineComponent,
     reactive,
     toRefs,
-    nextTick, ref,
+    nextTick, ref, toRef,
 } from 'vue';
-import type { DirectiveFunction, SetupContext, Ref } from 'vue';
+import type { DirectiveFunction, SetupContext } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
 import { groupBy, reduce } from 'lodash';
@@ -163,18 +163,8 @@ export default defineComponent<SelectDropdownProps>({
         },
     },
     setup(props, { emit, slots }: SetupContext) {
-        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
-        const {
-            targetRef, targetElement, contextMenuStyle,
-        } = useContextMenuFixedStyle({
-            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: visibleMenuRef,
-        });
-        const contextMenuFixedStyleState = reactive({
-            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
-        });
-
         const state = reactive({
+            visibleMenu: ref(props.visibleMenu || false),
             contextMenuRef: null as null|any,
             proxySelected: useProxyValue('selected', props, emit),
             selectedItem: computed<MenuItem|null>(() => {
@@ -199,6 +189,15 @@ export default defineComponent<SelectDropdownProps>({
             }, {})),
         });
 
+        const {
+            targetRef, targetElement, contextMenuStyle,
+        } = useContextMenuFixedStyle({
+            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
+            visibleMenu: toRef(state, 'visibleMenu'),
+        });
+        const contextMenuFixedStyleState = reactive({
+            targetRef, targetElement, contextMenuStyle,
+        });
 
         /* Event Handlers */
         const onSelectMenu = (item: MenuItem, index, event) => {
@@ -209,18 +208,18 @@ export default defineComponent<SelectDropdownProps>({
                 emit('select', item.name, event);
                 state.proxySelected = item.name;
             }
-            contextMenuFixedStyleState.visibleMenuRef = false;
+            state.visibleMenu = false;
         };
         const handleClick = (e: MouseEvent) => {
             if (props.readOnly || props.disabled) return;
-            contextMenuFixedStyleState.visibleMenuRef = !contextMenuFixedStyleState.visibleMenuRef;
+            state.visibleMenu = !state.visibleMenu;
             e.stopPropagation();
         };
         const handleClickOutside = (): void => {
-            contextMenuFixedStyleState.visibleMenuRef = false;
+            state.visibleMenu = false;
         };
         const handlePressDownKey = () => {
-            if (!contextMenuFixedStyleState.visibleMenuRef) contextMenuFixedStyleState.visibleMenuRef = true;
+            if (!state.visibleMenu) state.visibleMenu = true;
             nextTick(() => {
                 if (state.contextMenuRef) {
                     if (slots['menu-menu']) emit('focus-menu');

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -209,7 +209,7 @@ export default defineComponent<TextInputProps>({
 
     setup(props, { emit, listeners, attrs }) {
         const state = reactive({
-            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
+            proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
             menuRef: null,
             targetRef: null,
             isFocused: false,

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -66,7 +66,7 @@
                 <slot name="right-edge" v-bind="{ value }" />
             </span>
         </div>
-        <p-context-menu v-if="visibleMenu && useAutoComplete"
+        <p-context-menu v-if="proxyVisibleMenu && useAutoComplete"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :highlight-term="proxyValue"
@@ -81,7 +81,7 @@
 <script lang="ts">
 import type { PropType } from 'vue';
 import {
-    computed, defineComponent, reactive, ref, toRef, toRefs, watch,
+    computed, defineComponent, reactive, toRef, toRefs, watch,
 } from 'vue';
 
 import vClickOutside from 'v-click-outside';
@@ -209,7 +209,7 @@ export default defineComponent<TextInputProps>({
 
     setup(props, { emit, listeners, attrs }) {
         const state = reactive({
-            visibleMenu: ref(props.visibleMenu || false),
+            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
             menuRef: null,
             targetRef: null,
             isFocused: false,
@@ -235,7 +235,7 @@ export default defineComponent<TextInputProps>({
             targetRef, targetElement, contextMenuStyle,
         } = useContextMenuFixedStyle({
             useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: toRef(state, 'visibleMenu'),
+            visibleMenu: toRef(state, 'proxyVisibleMenu'),
         });
         const contextMenuFixedStyleState = reactive({
             targetRef, targetElement, contextMenuStyle,
@@ -256,12 +256,12 @@ export default defineComponent<TextInputProps>({
         };
 
         const hideMenu = () => {
-            state.visibleMenu = false;
+            state.proxyVisibleMenu = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            state.visibleMenu = true;
+            state.proxyVisibleMenu = true;
             emit('show-menu');
         };
 

--- a/src/inputs/input/PTextInput.vue
+++ b/src/inputs/input/PTextInput.vue
@@ -66,7 +66,7 @@
                 <slot name="right-edge" v-bind="{ value }" />
             </span>
         </div>
-        <p-context-menu v-if="visibleMenuRef && useAutoComplete"
+        <p-context-menu v-if="visibleMenu && useAutoComplete"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :highlight-term="proxyValue"
@@ -79,9 +79,9 @@
 </template>
 
 <script lang="ts">
-import type { PropType, Ref } from 'vue';
+import type { PropType } from 'vue';
 import {
-    computed, defineComponent, reactive, ref, toRefs, watch,
+    computed, defineComponent, reactive, ref, toRef, toRefs, watch,
 } from 'vue';
 
 import vClickOutside from 'v-click-outside';
@@ -208,18 +208,8 @@ export default defineComponent<TextInputProps>({
     },
 
     setup(props, { emit, listeners, attrs }) {
-        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
-        const {
-            targetRef, targetElement, contextMenuStyle,
-        } = useContextMenuFixedStyle({
-            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: visibleMenuRef,
-        });
-        const contextMenuFixedStyleState = reactive({
-            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
-        });
-
         const state = reactive({
+            visibleMenu: ref(props.visibleMenu || false),
             menuRef: null,
             targetRef: null,
             isFocused: false,
@@ -241,6 +231,15 @@ export default defineComponent<TextInputProps>({
             filteredMenu: [] as MenuItem[],
             bindingMenu: computed<SearchDropdownMenuItem[]>(() => (props.disableHandler ? props.menu : state.filteredMenu)),
         });
+        const {
+            targetRef, targetElement, contextMenuStyle,
+        } = useContextMenuFixedStyle({
+            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
+            visibleMenu: toRef(state, 'visibleMenu'),
+        });
+        const contextMenuFixedStyleState = reactive({
+            targetRef, targetElement, contextMenuStyle,
+        });
 
         const handleDeleteTag = (val, idx) => {
             const _selectedItems: SelectedItem[] = [...state.proxySelectedValue];
@@ -257,12 +256,12 @@ export default defineComponent<TextInputProps>({
         };
 
         const hideMenu = () => {
-            contextMenuFixedStyleState.visibleMenuRef = false;
+            state.visibleMenu = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            contextMenuFixedStyleState.visibleMenuRef = true;
+            state.visibleMenu = true;
             emit('show-menu');
         };
 

--- a/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
+++ b/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
@@ -145,7 +145,7 @@ export default defineComponent<AutocompleteSearchProps>({
         const vm = getCurrentInstance()?.proxy as Vue;
 
         const state = reactive({
-            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
+            proxyVisibleMenu: useProxyValue<boolean | undefined>('visibleMenu', props, emit),
             menuRef: null,
             proxyValue: makeOptionalProxy('value', vm, ''),
             isAutoMode: computed(() => props.visibleMenu === undefined),

--- a/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
+++ b/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
@@ -13,7 +13,7 @@
                 <slot :name="`search-${slot}`" v-bind="{...scope}" />
             </template>
         </p-search>
-        <p-context-menu v-if="visibleMenuRef"
+        <p-context-menu v-if="visibleMenu"
                         ref="menuRef"
                         :menu="bindingMenu"
                         :loading="loading"
@@ -33,9 +33,8 @@
 
 <script lang="ts">
 import {
-    computed, defineComponent, getCurrentInstance, onMounted, onUnmounted, reactive, ref, toRefs, watch,
+    computed, defineComponent, getCurrentInstance, onMounted, onUnmounted, reactive, ref, toRef, toRefs, watch,
 } from 'vue';
-import type { Ref } from 'vue';
 import type { Vue } from 'vue/types/vue';
 
 import Fuse from 'fuse.js';
@@ -143,19 +142,9 @@ export default defineComponent<AutocompleteSearchProps>({
     },
     setup(props: AutocompleteSearchProps, { emit, slots, listeners }) {
         const vm = getCurrentInstance()?.proxy as Vue;
-        const visibleMenuRef: Ref<boolean> = ref<boolean>(props.visibleMenu || false);
-
-        const {
-            targetRef, targetElement, contextMenuStyle,
-        } = useContextMenuFixedStyle({
-            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-            visibleMenu: visibleMenuRef,
-        });
-        const contextMenuFixedStyleState = reactive({
-            visibleMenuRef, targetRef, targetElement, contextMenuStyle,
-        });
 
         const state = reactive({
+            visibleMenu: ref(props.visibleMenu || false),
             menuRef: null,
             proxyValue: makeOptionalProxy('value', vm, ''),
             isAutoMode: computed(() => props.visibleMenu === undefined),
@@ -165,7 +154,15 @@ export default defineComponent<AutocompleteSearchProps>({
             searchableItems: computed<MenuItem[]>(() => props.menu.filter(d => d.type === undefined || d.type === 'item')),
             fuse: computed(() => new Fuse(state.searchableItems, fuseOptions)),
         });
-
+        const {
+            targetRef, targetElement, contextMenuStyle,
+        } = useContextMenuFixedStyle({
+            useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
+            visibleMenu: toRef(state, 'visibleMenu'),
+        });
+        const contextMenuFixedStyleState = reactive({
+            targetRef, targetElement, contextMenuStyle,
+        });
 
         // const defaultHandler = (inputText: string, list: MenuItem[]) => {
         //     let results: MenuItem[] = [...list];
@@ -221,12 +218,12 @@ export default defineComponent<AutocompleteSearchProps>({
         };
 
         const hideMenu = () => {
-            if (state.isAutoMode) contextMenuFixedStyleState.visibleMenuRef = false;
+            if (state.isAutoMode) state.visibleMenu = false;
             emit('hide-menu');
         };
 
         const showMenu = () => {
-            if (state.isAutoMode) contextMenuFixedStyleState.visibleMenuRef = true;
+            if (state.isAutoMode) state.visibleMenu = true;
             emit('show-menu');
         };
 
@@ -243,7 +240,7 @@ export default defineComponent<AutocompleteSearchProps>({
         };
 
         const onWindowKeydown = (e: KeyboardEvent) => {
-            if (contextMenuFixedStyleState.visibleMenuRef && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
+            if (state.visibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
                 e.preventDefault();
             }
         };
@@ -278,7 +275,7 @@ export default defineComponent<AutocompleteSearchProps>({
         }, {}));
 
         const onInput = (val: string, e) => {
-            if (!contextMenuFixedStyleState.visibleMenuRef) showMenu();
+            if (!state.visibleMenu) showMenu();
 
             state.proxyValue = val;
             emit('input', val, e);

--- a/src/inputs/search/query-search/PQuerySearch.vue
+++ b/src/inputs/search/query-search/PQuerySearch.vue
@@ -62,9 +62,11 @@
 </template>
 
 <script lang="ts">
-import type { PropType, SetupContext, DirectiveFunction } from 'vue';
+import type {
+    PropType, SetupContext, DirectiveFunction, Ref,
+} from 'vue';
 import {
-    computed, defineComponent, toRefs,
+    computed, defineComponent, ref, toRefs,
 } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
@@ -126,16 +128,25 @@ export default defineComponent({
     },
     setup(props, context: SetupContext) {
         const { slots, emit } = context;
+        const visibleMenuRef: Ref<boolean> = ref<boolean>(false);
         const {
             state,
             focus, blur, hideMenu, showMenu,
             onInput,
-            onKeyupEnter,
             onKeydownCheck,
+            onKeyupEnter,
             onPaste,
             onDeleteAll,
             preTreatSelectedMenuItem,
-        } = useQuerySearch(props);
+        } = useQuerySearch(
+            {
+                value: props.value,
+                focused: props.focused,
+                valueHandlerMap: computed(() => props.valueHandlerMap),
+                keyItemSets: computed(() => props.keyItemSets),
+                visibleMenu: visibleMenuRef,
+            },
+        );
 
         /* event */
         const onMenuSelect = async (item: KeyMenuItem | ValueMenuItem) => {

--- a/src/inputs/search/query-search/PQuerySearch.vue
+++ b/src/inputs/search/query-search/PQuerySearch.vue
@@ -66,7 +66,7 @@ import type {
     PropType, SetupContext, DirectiveFunction,
 } from 'vue';
 import {
-    computed, defineComponent, reactive, ref, toRef, toRefs,
+    computed, defineComponent, reactive, toRef, toRefs,
 } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
@@ -129,8 +129,8 @@ export default defineComponent({
     setup(props, context: SetupContext) {
         const { slots, emit } = context;
         const state = reactive({
-            visibleMenu: ref<boolean>(false),
-            value: ref(props.value),
+            visibleMenu: false,
+            value: props.value,
         });
         const {
             state: querySearchState,

--- a/src/inputs/search/query-search/PQuerySearch.vue
+++ b/src/inputs/search/query-search/PQuerySearch.vue
@@ -63,10 +63,10 @@
 
 <script lang="ts">
 import type {
-    PropType, SetupContext, DirectiveFunction, Ref,
+    PropType, SetupContext, DirectiveFunction,
 } from 'vue';
 import {
-    computed, defineComponent, ref, toRefs,
+    computed, defineComponent, reactive, ref, toRef, toRefs,
 } from 'vue';
 
 import { vOnClickOutside } from '@vueuse/components';
@@ -128,9 +128,12 @@ export default defineComponent({
     },
     setup(props, context: SetupContext) {
         const { slots, emit } = context;
-        const visibleMenuRef: Ref<boolean> = ref<boolean>(false);
+        const state = reactive({
+            visibleMenu: ref<boolean>(false),
+            value: ref(props.value),
+        });
         const {
-            state,
+            state: querySearchState,
             focus, blur, hideMenu, showMenu,
             onInput,
             onKeydownCheck,
@@ -140,11 +143,11 @@ export default defineComponent({
             preTreatSelectedMenuItem,
         } = useQuerySearch(
             {
-                value: props.value,
                 focused: props.focused,
-                valueHandlerMap: computed(() => props.valueHandlerMap),
-                keyItemSets: computed(() => props.keyItemSets),
-                visibleMenu: visibleMenuRef,
+                valueHandlerMap: toRef(props, 'valueHandlerMap'),
+                keyItemSets: toRef(props, 'keyItemSets'),
+                visibleMenu: toRef(state, 'visibleMenu'),
+                value: toRef(state, 'value'),
             },
         );
 
@@ -174,7 +177,7 @@ export default defineComponent({
         }, {}));
 
         return {
-            ...toRefs(state),
+            ...toRefs(querySearchState),
             focus,
             blur,
             showMenu,

--- a/src/inputs/search/query-search/type.ts
+++ b/src/inputs/search/query-search/type.ts
@@ -1,3 +1,5 @@
+import type { Ref, ComputedRef } from 'vue';
+
 import type { ContextMenuType } from '@/inputs/context-menu/type';
 
 
@@ -80,13 +82,12 @@ export interface KeyItemSet {
     items: KeyItem[];
 }
 
-
-export interface QuerySearchProps {
-    placeholder?: string;
-    focused: boolean;
-    keyItemSets: KeyItemSet[];
-    valueHandlerMap: ValueHandlerMap;
-    value: string;
+export interface QuerySearchStateArgs {
+    focused: ComputedRef<boolean> | boolean;
+    keyItemSets: ComputedRef<KeyItemSet[]> | KeyItemSet[];
+    valueHandlerMap: ComputedRef<ValueHandlerMap> | ValueHandlerMap;
+    value: ComputedRef<string> | string;
+    visibleMenu: Ref<boolean>;
 }
 
 export interface QuerySearchEventArgs {

--- a/src/inputs/search/query-search/type.ts
+++ b/src/inputs/search/query-search/type.ts
@@ -1,5 +1,3 @@
-import type { Ref, ComputedRef } from 'vue';
-
 import type { ContextMenuType } from '@/inputs/context-menu/type';
 
 
@@ -80,14 +78,6 @@ export interface ValueHandlerMap {
 export interface KeyItemSet {
     title: string;
     items: KeyItem[];
-}
-
-export interface QuerySearchStateArgs {
-    focused: ComputedRef<boolean> | boolean;
-    keyItemSets: ComputedRef<KeyItemSet[]> | KeyItemSet[];
-    valueHandlerMap: ComputedRef<ValueHandlerMap> | ValueHandlerMap;
-    value: ComputedRef<string> | string;
-    visibleMenu: Ref<boolean>;
 }
 
 export interface QuerySearchEventArgs {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console

### Description

Query Search hook
- Renewal `useQuerySearch` hook.
- Unlike before, `visibleMenu` is injected as props with `Ref<boolean>` type.
- Props injection method has changed.
- Args type has changed.

Query Search Dropdown
- Fixed layout issue derived from `ContextMenuFixedStyle` hook has fixed.
- Some style has changed.
- Storybook has been updated.

Query Search
- Changes in `useQuerySearch` have been applied.

---

Query Search hook
- `useQuerySearch` 훅이 업데이트 되었습니다.
- 전과 다르게, `visibleMenu`가 `Ref<boolean>` 타입의 프롭스로 주입됩니다.
- 프롭스의 주입방식이 바뀌었습니다.
- Args 타입이 변경되었습니다.

Query Search Dropdown
- 변경된 `ContextMenuFixedStyle`에서 야기된 문제를 해결하였습니다.
- 몇몇 스타일이 수정되었습니다.
- Storybook이 업데이트 되었습니다.

Query Search
- 변경된 `useQuerySearch`에 맞게 수정되었습니다.
