### PR TITLE
fix(p-icon-button): update style

### DIFF
--- a/src/inputs/buttons/button/PButton.stories.mdx
+++ b/src/inputs/buttons/button/PButton.stories.mdx
@@ -136,14 +136,31 @@ export const Template = (args, {argTypes})=>({
         {{
             components:{ PButton, PLottie },
             template: `
-                <div style="display:flex; align-items:center; justify-content:center; margin-top: 50px; background-color: white">
-                    <p-button
-                        styleType="primary"
-                        :disabled="true"
-                    >
-                        <div>Disabled</div>
+                <div style="display: flex; flex-direction: column; align-items: center; background-color: white">
+                <div style="display:flex">
+                    <p-button v-for="styleType in buttonStyles.slice(0, 4)" :style-type="styleType" disabled style="margin-right: 20px">
+                        <div>{{ styleType }}</div>
                     </p-button>
+                </div>
+                <div style="display:flex; margin-top: 20px">
+                    <p-button v-for="styleType in buttonStyles.slice(4, 7)" :style-type="styleType" disabled style="margin-right: 20px">
+                        <div>{{ styleType }}</div>
+                    </p-button>
+                </div>
+                <div style="display:flex; margin-top: 20px">
+                    <p-button v-for="styleType in buttonStyles.slice(7)" :style-type="styleType" disabled style="margin-right: 20px">
+                        <div>{{ styleType }}</div>
+                    </p-button>
+                </div>
                 </div>`,
+            setup() {
+                const state = reactive({
+                    buttonStyles: Object.values(BUTTON_STYLE),
+                })
+                return {
+                    ...toRefs(state),
+                }
+            }
         }}
     </Story>
 </Canvas>

--- a/src/inputs/buttons/button/PButton.vue
+++ b/src/inputs/buttons/button/PButton.vue
@@ -146,13 +146,10 @@ export default defineComponent<ButtonProps>({
             outline-color: theme('colors.blue.500');
         }
         &.disabled {
-            @apply bg-gray-200 text-gray-400;
+            @apply bg-gray-200 text-gray-400 border-transparent;
             cursor: not-allowed;
-        }
-        &.loading {
-            cursor: not-allowed;
-            > .p-spinner {
-                margin-right: 0.25em;
+            &:hover, &:active {
+                @apply bg-gray-200;
             }
         }
     }
@@ -210,6 +207,13 @@ export default defineComponent<ButtonProps>({
         @apply font-normal;
     }
 
+    &.loading {
+        cursor: not-allowed;
+        > .p-spinner {
+            margin-right: 0.25em;
+        }
+    }
+
     > .icon {
         flex-shrink: 0;
         &.left {
@@ -235,10 +239,20 @@ export default defineComponent<ButtonProps>({
         &:hover, &:focus {
             @apply text-blue-600;
         }
+        &.disabled {
+            &:hover, &:active, &:focus {
+                @apply bg-gray-200 text-gray-400 border-transparent;
+            }
+        }
     }
     &.negative-secondary {
         &:hover, &:active {
             @apply text-red-500 border-red-200;
+        }
+        &.disabled {
+            &:hover, &:active, &:focus {
+                @apply bg-gray-200 text-gray-400 border-transparent;
+            }
         }
     }
     &.negative-transparent {
@@ -248,6 +262,11 @@ export default defineComponent<ButtonProps>({
         }
         &:active {
             @apply text-white;
+        }
+        &.disabled {
+            &:hover, &:active, &:focus {
+                @apply bg-gray-200 text-gray-400 border-transparent;
+            }
         }
     }
 }

--- a/src/inputs/buttons/icon-button/PIconButton.stories.mdx
+++ b/src/inputs/buttons/icon-button/PIconButton.stories.mdx
@@ -4,6 +4,7 @@ import PIconButton from "@/inputs/buttons/icon-button/PIconButton";
 
 import { getIconButtonArgTypes } from '@/inputs/buttons/icon-button/story-helper';
 import {ICON_BUTTON_STYLE_TYPE} from '@/inputs/buttons/icon-button/type';
+import { reactive, toRefs } from 'vue';
 
 <Meta title='Inputs/Buttons/IconButton' parameters={{
     design: {
@@ -26,7 +27,6 @@ export const Template = (args, { argTypes }) => ({
                 :disabled="disabled"
                 :activated="activated"
                 :loading="loading"
-                :outline="outline"
                 :size="size"
                 :animation="animation"
             />
@@ -64,25 +64,81 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
-## Outlined
+## Style
 
 <Canvas>
     <Story name="Outlined">
         {{
             components:{ PIconButton },
             template: `
-                <div style="text-align:center">
-                    <p-icon-button style-type="primary" :outline="true" style="margin: 1rem" name="ic_refresh" />
-                    <p-icon-button style-type="secondary" :outline="true" style="margin: 1rem" name="ic_refresh" />
-                    <p-icon-button style-type="alert" :outline="true" style="margin: 1rem" name="ic_refresh" />
-                    <p-icon-button style-type="safe" :outline="true" style="margin: 1rem" name="ic_refresh" />
-                </div>`,
+<table>
+    <tr>
+        <td>tertiary</td>
+        <td><p-icon-button style-type="tertiary" style="margin: 0.5rem" name="ic_refresh" /></td>
+    </tr>
+    <tr>
+        <td>transparent</td>
+        <td><p-icon-button style-type="transparent" style="margin: 0.5rem" name="ic_refresh" /></td>
+    </tr>
+    <tr>
+        <td>negative-secondary</td>
+        <td><p-icon-button style-type="negative-secondary" style="margin: 0.5rem" name="ic_refresh" /></td>
+    </tr>
+    <tr>
+        <td>negative-transparent</td>
+        <td><p-icon-button style-type="negative-transparent" style="margin: 0.5rem" name="ic_refresh" /></td>
+    </tr>
+</table>`,
+            setup() {
+                const state = reactive({
+                    buttonStyles: Object.values(ICON_BUTTON_STYLE_TYPE),
+                })
+                return {
+                    ...toRefs(state),
+                }
+            }
         }}
     </Story>
 </Canvas>
 
 <br/>
 <br/>
+
+## Shape
+<Canvas>
+    <Story name="Shape">
+        {{
+            components:{ PIconButton },
+            template: `
+<table>
+    <tr>
+        <td>tertiary</td>
+        <td><p-icon-button style-type="tertiary" style="margin: 0.5rem" name="ic_refresh" /></td>
+        <td><p-icon-button style-type="tertiary" style="margin: 0.5rem" name="ic_refresh" shape="circle" /></td>
+    </tr>
+    <tr>
+        <td>transparent</td>
+        <td><p-icon-button style-type="transparent" style="margin: 0.5rem" name="ic_refresh" /></td>
+        <td><p-icon-button style-type="transparent" style="margin: 0.5rem" name="ic_refresh" shape="circle" /></td>
+    </tr>
+    <tr>
+        <td>negative-secondary</td>
+        <td><p-icon-button style-type="negative-secondary" style="margin: 0.5rem" name="ic_refresh" /></td>
+        <td><p-icon-button style-type="negative-secondary" style="margin: 0.5rem" name="ic_refresh" shape="circle" /></td>
+    </tr>
+    <tr>
+        <td>negative-transparent</td>
+        <td><p-icon-button style-type="negative-transparent" style="margin: 0.5rem" name="ic_refresh" /></td>
+        <td><p-icon-button style-type="negative-transparent" style="margin: 0.5rem" name="ic_refresh" shape="circle" /></td>
+    </tr>
+</table>`,
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
 
 ## Disabled
 
@@ -91,13 +147,24 @@ export const Template = (args, { argTypes }) => ({
         {{
             components:{ PIconButton },
             template: `
-                <div style="text-align:center">
-                    <p-icon-button style-type="primary" style="margin: 1rem" name="ic_refresh" />
-                    <p-icon-button style-type="primary" :disabled="true" style="margin: 1rem" name="ic_refresh" />
-                    <br/>
-                    <p-icon-button style-type="transparent" style="margin: 1rem" name="ic_refresh" />
-                    <p-icon-button style-type="transparent" :disabled="true" style="margin: 1rem" name="ic_refresh" />
-                </div>`,
+<table>
+    <tr>
+        <td>tertiary</td>
+        <td><p-icon-button style-type="tertiary" style="margin: 0.5rem" name="ic_refresh" disabled /></td>
+    </tr>
+    <tr>
+        <td>transparent</td>
+        <td><p-icon-button style-type="transparent" style="margin: 0.5rem" name="ic_refresh" disabled /></td>
+    </tr>
+    <tr>
+        <td>negative-secondary</td>
+        <td><p-icon-button style-type="negative-secondary" style="margin: 0.5rem" name="ic_refresh" disabled /></td>
+    </tr>
+    <tr>
+        <td>negative-transparent</td>
+        <td><p-icon-button style-type="negative-transparent" style="margin: 0.5rem" name="ic_refresh" disabled /></td>
+    </tr>
+</table>`,
         }}
     </Story>
 </Canvas>
@@ -113,11 +180,8 @@ export const Template = (args, { argTypes }) => ({
             components:{ PIconButton },
             template: `
                 <div style="text-align:center">
-                    <p-icon-button style-type="primary" animation="spin" style="margin: 1rem" name="ic_refresh" />
-                    <br/>
-                    <p-icon-button style-type="transparent" animation="spin" style="margin: 1rem" name="ic_refresh" />
-                    <br/>
-                    <p-icon-button style-type="gray-border" animation="spin" style="margin: 1rem" name="ic_refresh" />
+                    <p-icon-button style-type="tertiary" animation="spin" style="margin: 0.5rem" name="ic_refresh" />
+                    <p-icon-button style-type="transparent" animation="spin" style="margin: 0.5rem" name="ic_refresh" />
                 </div>`,
         }}
     </Story>
@@ -135,8 +199,8 @@ export const Template = (args, { argTypes }) => ({
             components:{ PIconButton },
             template: `
                 <div style="text-align:center">
-                    <p-icon-button style-type="gray-border" style="margin: 1rem" name="ic_refresh" />
-                    <p-icon-button style-type="gray-border" :activated="true" style="margin: 1rem" name="ic_refresh" />
+                    <p-icon-button style-type="transparent" style="margin: 0.5rem" name="ic_refresh" />
+                    <p-icon-button style-type="transparent" :activated="true" style="margin: 0.5rem" name="ic_refresh" />
                 </div>`,
         }}
     </Story>
@@ -163,35 +227,19 @@ export const Template = (args, { argTypes }) => ({
     </thead>
     <tbody>
         <template v-for="(styleType) in styleTypes">
-        <tr :key="styleType+'default'">
-            <th rowspan="2">{{styleType}}</th>
-            <th>default</th>
-            <td><p-icon-button :style-type="styleType" name="ic_search" /></td>
-            <td><p-icon-button :style-type="styleType" name="ic_search" disabled /></td>
-            <td><p-icon-button :style-type="styleType" name="ic_search" loading /></td>
-            <td><p-icon-button :style-type="styleType" name="ic_search" activated /></td>
-        </tr>
-        <tr :key="styleType+'outline'">
-            <th>outline</th>
-            <td><p-icon-button :style-type="styleType" name="ic_search" outline /></td>
-            <td><p-icon-button :style-type="styleType" name="ic_search" outline disabled /></td>
-            <td><p-icon-button :style-type="styleType" name="ic_search" outline loading /></td>
-            <td><p-icon-button :style-type="styleType" name="ic_search" outline activated /></td>
-        </tr>
+            <tr :key="styleType">
+                <th colspan="2">{{styleType}}</th>
+                <td><p-icon-button :style-type="styleType" name="ic_search" /></td>
+                <td><p-icon-button :style-type="styleType" name="ic_search" disabled /></td>
+                <td><p-icon-button :style-type="styleType" name="ic_search" loading /></td>
+                <td><p-icon-button :style-type="styleType" name="ic_search" activated /></td>
+            </tr>
         </template>
     </tbody>
 </table>`,
             setup() {
                 return {
-                    styleTypes: Object.values(ICON_BUTTON_STYLE_TYPE).sort((a, b) => {
-                        if (a === 'transparent') return -1
-                        if (a === 'gray-border') {
-                            if (b === 'transparent') return 1
-                            return -1
-                        }
-                        if (a < b) return -1;
-                        if (a > b) return 1;
-                    })
+                    styleTypes: Object.values(ICON_BUTTON_STYLE_TYPE)
                 }
             }
         }}

--- a/src/inputs/buttons/icon-button/PIconButton.vue
+++ b/src/inputs/buttons/icon-button/PIconButton.vue
@@ -1,7 +1,7 @@
 <template>
     <p-button
         class="p-icon-button"
-        :class="{ activated, [size]: true, loading}"
+        :class="{ activated, [size]: true, loading, [shape]: true }"
         :style-type="styleType"
         :disabled="disabled || loading"
         v-on="$listeners"
@@ -29,8 +29,11 @@ import { ANIMATION_TYPE } from '@/foundation/icons/config';
 import PI from '@/foundation/icons/PI.vue';
 import PButton from '@/inputs/buttons/button/PButton.vue';
 import type { ButtonSize } from '@/inputs/buttons/button/type';
+import type {
+    IconButtonProps, IconButtonShape, IconButtonSize, IconButtonStyleType,
+} from '@/inputs/buttons/icon-button/type';
 import {
-    ICON_BUTTON_SIZE, ICON_BUTTON_STYLE_TYPE,
+    ICON_BUTTON_SHAPE, ICON_BUTTON_SIZE, ICON_BUTTON_STYLE_TYPE,
 } from '@/inputs/buttons/icon-button/type';
 
 
@@ -39,7 +42,7 @@ const LOADING_SIZE: Record<ButtonSize, string> = {
     md: SPINNER_SIZE.lg,
     lg: SPINNER_SIZE.xl,
 };
-export default defineComponent({
+export default defineComponent<IconButtonProps>({
     name: 'PIconButton',
     components: { PSpinner, PButton, PI },
     props: {
@@ -49,8 +52,10 @@ export default defineComponent({
         },
         styleType: {
             type: String,
-            default: 'transparent',
-            validator: value => Object.keys(ICON_BUTTON_STYLE_TYPE).includes(value as string),
+            default: ICON_BUTTON_STYLE_TYPE.transparent,
+            validator(value: IconButtonStyleType) {
+                return Object.values(ICON_BUTTON_STYLE_TYPE).includes(value);
+            },
         },
         color: {
             type: String,
@@ -68,20 +73,25 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
-        outline: {
-            type: Boolean,
-            default: false,
-        },
         size: {
             type: String,
             default: 'md',
-            validator: value => Object.keys(ICON_BUTTON_SIZE).includes(value as string),
+            validator(value: IconButtonSize) {
+                return Object.keys(ICON_BUTTON_SIZE).includes(value);
+            },
         },
         animation: {
             type: String,
             default: undefined,
             validator(animation: any) {
                 return animation === undefined || Object.values(ANIMATION_TYPE).includes(animation);
+            },
+        },
+        shape: {
+            type: String,
+            default: ICON_BUTTON_SHAPE.circle,
+            validator(value: IconButtonShape) {
+                return Object.values(ICON_BUTTON_SHAPE).includes(value);
             },
         },
     },
@@ -104,7 +114,7 @@ export default defineComponent({
     min-height: 2rem;
     max-width: 2rem;
     max-height: 2rem;
-    > .p-lottie {
+    > .p-spinner {
         flex-shrink: 0;
     }
     > .p-i-icon {
@@ -124,25 +134,41 @@ export default defineComponent({
         max-height: 1.5rem;
     }
 
-    /* style types */
-    &.transparent {
-        @apply rounded-full;
-        &.loading:hover {
-            @apply bg-transparent;
-        }
-        &.activated {
-            @apply text-secondary;
+    &.loading {
+        > .p-spinner {
+            margin-right: 0;
         }
     }
-    &.gray-border {
-        &:not(.loading):not(.disabled) {
-            @apply border-gray-300;
+
+    &.circle {
+        @apply rounded-full;
+    }
+
+    &.disabled {
+        @apply border-transparent;
+        &:hover, &:active, &:focus {
+            @apply border-transparent;
         }
-        &:not(.disabled):not(.loading):not(.activated):hover {
-            @apply text-gray-900 border-gray-900;
-        }
+    }
+
+    /* style types */
+    &.transparent {
         &.activated {
-            @apply text-secondary border-secondary;
+            @apply text-blue-600;
+        }
+        &.disabled {
+            @apply bg-transparent;
+            &:hover, &:active, &:focus {
+                @apply bg-transparent;
+            }
+        }
+    }
+    &.negative-transparent {
+        &.disabled {
+            @apply bg-transparent;
+            &:hover, &:active, &:focus {
+                @apply bg-transparent;
+            }
         }
     }
 }

--- a/src/inputs/buttons/icon-button/type.ts
+++ b/src/inputs/buttons/icon-button/type.ts
@@ -1,40 +1,32 @@
 export const ICON_BUTTON_STYLE_TYPE = {
-    primary: 'primary',
-    'primary-dark': 'primary-dark',
-    primary1: 'primary1',
-    primary2: 'primary2',
-    secondary: 'secondary',
-    secondary1: 'secondary1',
-    gray: 'gray',
-    gray900: 'gray900',
-    alert: 'alert',
-    safe: 'safe',
+    tertiary: 'tertiary',
     transparent: 'transparent',
-    'gray-border': 'gray-border',
+    'negative-secondary': 'negative-secondary',
+    'negative-transparent': 'negative-transparent',
 } as const;
-export type ICON_BUTTON_STYLE_TYPE = typeof ICON_BUTTON_STYLE_TYPE[keyof typeof ICON_BUTTON_STYLE_TYPE]
+export type IconButtonStyleType = typeof ICON_BUTTON_STYLE_TYPE[keyof typeof ICON_BUTTON_STYLE_TYPE]
 
 export const ICON_BUTTON_SHAPE = {
     circle: 'circle',
     square: 'square',
 } as const;
-export type ICON_BUTTON_SHAPE = typeof ICON_BUTTON_SHAPE[keyof typeof ICON_BUTTON_SHAPE];
+export type IconButtonShape = typeof ICON_BUTTON_SHAPE[keyof typeof ICON_BUTTON_SHAPE];
 
 export const ICON_BUTTON_SIZE = {
     sm: '1rem',
     md: '1.5rem',
     lg: '2rem',
 } as const;
-export type ICON_BUTTON_SIZE = typeof ICON_BUTTON_SIZE[keyof typeof ICON_BUTTON_SIZE]
+export type IconButtonSize = typeof ICON_BUTTON_SIZE[keyof typeof ICON_BUTTON_SIZE]
 
 export interface IconButtonProps {
     name: string;
     loading: boolean;
-    styleType: ICON_BUTTON_STYLE_TYPE;
+    styleType: IconButtonStyleType;
     color: string;
     disabled: boolean;
     activated: boolean;
-    outline: boolean;
-    size: ICON_BUTTON_SIZE;
-    shape: ICON_BUTTON_SHAPE;
+    size: IconButtonSize;
+    animation?: boolean;
+    shape: IconButtonShape;
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [ ] Tested with console

### Description
> `PIconButton` has only 4 `styleType` (default is transparent)

![스크린샷 2022-10-31 오후 1 13 36](https://user-images.githubusercontent.com/18563857/198929856-b630cfa5-33df-4e2b-94a0-29b16dbd730d.png)

- update `styleType`
- delete `outline`
- add `shape` (`circle` / `square` - default if circle)
