### PR TITLE
feat(p-tooltip): add position props and fix style

### DIFF
--- a/css/PTooltip.css
+++ b/css/PTooltip.css
@@ -2,11 +2,13 @@
   display: block !important;
   z-index: 10000;
   font-size: 0.75rem;
+  line-height: 1.5;
 }
 
 .p-tooltip .tooltip-inner {
-    border-radius: 0;
-    background: black;
+    border-radius: 0.25rem;
+    max-width: 640px;
+    background-color: rgba(35,37,51, 0.9);
     color: white;
     padding: 5px 8px;
   }
@@ -17,7 +19,7 @@
     border-style: solid;
     position: absolute;
     margin: 5px;
-    border-color: black;
+    border-color: rgba(35,37,51, 0.9);
     z-index: 1;
   }
 
@@ -26,12 +28,12 @@
   }
 
 .p-tooltip[x-placement^="top"] .tooltip-arrow {
-      border-width: 11px 7.5px 0 7.5px;
+      border-width: 8px 6px 0 6px;
       border-left-color: transparent !important;
       border-right-color: transparent !important;
       border-bottom-color: transparent !important;
-      bottom: -9px;
-      left: calc(50% - 11px);
+      bottom: -8px;
+      left: calc(50% - 6px);
       margin-top: 0;
       margin-bottom: 0;
     }
@@ -41,12 +43,12 @@
   }
 
 .p-tooltip[x-placement^="bottom"] .tooltip-arrow {
-      border-width: 0 7.5px 11px 7.5px;
+      border-width: 0 6px 8px 6px;
       border-left-color: transparent !important;
       border-right-color: transparent !important;
       border-top-color: transparent !important;
-      top: -9px;
-      left: calc(50% - 11px);
+      top: -8px;
+      left: calc(50% - 6px);
       margin-top: 0;
       margin-bottom: 0;
     }
@@ -56,12 +58,12 @@
   }
 
 .p-tooltip[x-placement^="right"] .tooltip-arrow {
-      border-width: 7.5px 11px 7.5px 0;
+      border-width: 6px 8px 6px 0;
       border-left-color: transparent !important;
       border-top-color: transparent !important;
       border-bottom-color: transparent !important;
-      left: -9px;
-      top: calc(50% - 13px);
+      left: -8px;
+      top: calc(50% - 6px);
       margin-left: 0;
       margin-right: 0;
     }
@@ -71,12 +73,12 @@
   }
 
 .p-tooltip[x-placement^="left"] .tooltip-arrow {
-      border-width: 7.5px 0 7.5px 11px;
+      border-width: 6px 0 6px 8px;
       border-top-color: transparent !important;
       border-right-color: transparent !important;
       border-bottom-color: transparent !important;
-      right: -9px;
-      top: calc(50% - 13px);
+      right: -8px;
+      top: calc(50% - 6px);
       margin-left: 0;
       margin-right: 0;
     }
@@ -109,4 +111,16 @@
     opacity: 1;
     -webkit-transition: opacity 0.15s;
     transition: opacity 0.15s;
+  }
+
+@media (max-width: 1023px) {
+    .p-tooltip .tooltip-inner {
+      max-width: 320px;
+    }
+  }
+
+@media (max-width: 767px) {
+    .p-tooltip .tooltip-inner {
+      max-width: 240px;
+    }
   }

--- a/css/light-style.css
+++ b/css/light-style.css
@@ -13,7 +13,7 @@ html:lang(en), body:lang(en) {
  */
 
 html, body {
-  font-family: Noto Sans, Roboto, arial, sans-serif;
+  font-family: noto sans, roboto, arial, sans-serif;
   font-size: 16px;
   font-weight: 400;
   width: 100vw;
@@ -54,7 +54,7 @@ input:focus {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: Noto Sans, Roboto, arial, sans-serif;
+  font-family: noto sans, roboto, arial, sans-serif;
   margin: 0;
   color: inherit;
   word-spacing: inherit;
@@ -86,11 +86,13 @@ summary {
   display: block !important;
   z-index: 10000;
   font-size: 0.75rem;
+  line-height: 1.5;
 }
 
 .p-tooltip .tooltip-inner {
-    border-radius: 0;
-    background: black;
+    border-radius: 0.25rem;
+    max-width: 640px;
+    background-color: rgba(35,37,51, 0.9);
     color: white;
     padding: 5px 8px;
   }
@@ -101,7 +103,7 @@ summary {
     border-style: solid;
     position: absolute;
     margin: 5px;
-    border-color: black;
+    border-color: rgba(35,37,51, 0.9);
     z-index: 1;
   }
 
@@ -110,12 +112,12 @@ summary {
   }
 
 .p-tooltip[x-placement^="top"] .tooltip-arrow {
-      border-width: 11px 7.5px 0 7.5px;
+      border-width: 8px 6px 0 6px;
       border-left-color: transparent !important;
       border-right-color: transparent !important;
       border-bottom-color: transparent !important;
-      bottom: -9px;
-      left: calc(50% - 11px);
+      bottom: -8px;
+      left: calc(50% - 6px);
       margin-top: 0;
       margin-bottom: 0;
     }
@@ -125,12 +127,12 @@ summary {
   }
 
 .p-tooltip[x-placement^="bottom"] .tooltip-arrow {
-      border-width: 0 7.5px 11px 7.5px;
+      border-width: 0 6px 8px 6px;
       border-left-color: transparent !important;
       border-right-color: transparent !important;
       border-top-color: transparent !important;
-      top: -9px;
-      left: calc(50% - 11px);
+      top: -8px;
+      left: calc(50% - 6px);
       margin-top: 0;
       margin-bottom: 0;
     }
@@ -140,12 +142,12 @@ summary {
   }
 
 .p-tooltip[x-placement^="right"] .tooltip-arrow {
-      border-width: 7.5px 11px 7.5px 0;
+      border-width: 6px 8px 6px 0;
       border-left-color: transparent !important;
       border-top-color: transparent !important;
       border-bottom-color: transparent !important;
-      left: -9px;
-      top: calc(50% - 13px);
+      left: -8px;
+      top: calc(50% - 6px);
       margin-left: 0;
       margin-right: 0;
     }
@@ -155,12 +157,12 @@ summary {
   }
 
 .p-tooltip[x-placement^="left"] .tooltip-arrow {
-      border-width: 7.5px 0 7.5px 11px;
+      border-width: 6px 0 6px 8px;
       border-top-color: transparent !important;
       border-right-color: transparent !important;
       border-bottom-color: transparent !important;
-      right: -9px;
-      top: calc(50% - 13px);
+      right: -8px;
+      top: calc(50% - 6px);
       margin-left: 0;
       margin-right: 0;
     }
@@ -193,4 +195,16 @@ summary {
     opacity: 1;
     -webkit-transition: opacity 0.15s;
     transition: opacity 0.15s;
+  }
+
+@media (max-width: 1023px) {
+    .p-tooltip .tooltip-inner {
+      max-width: 320px;
+    }
+  }
+
+@media (max-width: 767px) {
+    .p-tooltip .tooltip-inner {
+      max-width: 240px;
+    }
   }

--- a/css/reset.css
+++ b/css/reset.css
@@ -11,7 +11,7 @@ html:lang(en), body:lang(en) {
  */
 
 html, body {
-  font-family: Noto Sans, Roboto, arial, sans-serif;
+  font-family: noto sans, roboto, arial, sans-serif;
   font-size: 16px;
   font-weight: 400;
   width: 100vw;
@@ -52,7 +52,7 @@ input:focus {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: Noto Sans, Roboto, arial, sans-serif;
+  font-family: noto sans, roboto, arial, sans-serif;
   margin: 0;
   color: inherit;
   word-spacing: inherit;

--- a/src/data-display/tooltips/PTooltip.pcss
+++ b/src/data-display/tooltips/PTooltip.pcss
@@ -1,12 +1,15 @@
 $space: 8px;
 .p-tooltip {
+    $tooltip-color: rgba(theme('colors.gray.900'), 0.9);
     display: block !important;
     z-index: 10000;
     font-size: 0.75rem;
+    line-height: 1.5;
 
     .tooltip-inner {
-        @apply rounded-none;
-        background: black;
+        @apply rounded-md;
+        max-width: 640px;
+        background-color: $tooltip-color;
         color: white;
         padding: 5px 8px;
     }
@@ -17,7 +20,7 @@ $space: 8px;
         border-style: solid;
         position: absolute;
         margin: 5px;
-        border-color: black;
+        border-color: $tooltip-color;
         z-index: 1;
     }
 
@@ -25,12 +28,12 @@ $space: 8px;
         margin-bottom: calc($(space));
 
         .tooltip-arrow {
-            border-width: 11px 7.5px 0 7.5px;
+            border-width: 8px 6px 0 6px;
             border-left-color: transparent !important;
             border-right-color: transparent !important;
             border-bottom-color: transparent !important;
-            bottom: -9px;
-            left: calc(50% - 11px);
+            bottom: -8px;
+            left: calc(50% - 6px);
             margin-top: 0;
             margin-bottom: 0;
         }
@@ -40,12 +43,12 @@ $space: 8px;
         margin-top: calc($(space));
 
         .tooltip-arrow {
-            border-width: 0 7.5px 11px 7.5px;
+            border-width: 0 6px 8px 6px;
             border-left-color: transparent !important;
             border-right-color: transparent !important;
             border-top-color: transparent !important;
-            top: -9px;
-            left: calc(50% - 11px);
+            top: -8px;
+            left: calc(50% - 6px);
             margin-top: 0;
             margin-bottom: 0;
         }
@@ -55,12 +58,12 @@ $space: 8px;
         margin-left: calc($(space));
 
         .tooltip-arrow {
-            border-width: 7.5px 11px 7.5px 0;
+            border-width: 6px 8px 6px 0;
             border-left-color: transparent !important;
             border-top-color: transparent !important;
             border-bottom-color: transparent !important;
-            left: -9px;
-            top: calc(50% - 13px);
+            left: -8px;
+            top: calc(50% - 6px);
             margin-left: 0;
             margin-right: 0;
         }
@@ -70,12 +73,12 @@ $space: 8px;
         margin-right: calc($(space));
 
         .tooltip-arrow {
-            border-width: 7.5px 0 7.5px 11px;
+            border-width: 6px 0 6px 8px;
             border-top-color: transparent !important;
             border-right-color: transparent !important;
             border-bottom-color: transparent !important;
-            right: -9px;
-            top: calc(50% - 13px);
+            right: -8px;
+            top: calc(50% - 6px);
             margin-left: 0;
             margin-right: 0;
         }
@@ -107,5 +110,17 @@ $space: 8px;
         visibility: visible;
         opacity: 1;
         transition: opacity 0.15s;
+    }
+
+    @screen tablet {
+        .tooltip-inner {
+            max-width: 320px;
+        }
+    }
+
+    @screen mobile {
+        .tooltip-inner {
+            max-width: 240px;
+        }
     }
 }

--- a/src/data-display/tooltips/PTooltip.stories.mdx
+++ b/src/data-display/tooltips/PTooltip.stories.mdx
@@ -1,9 +1,11 @@
 import {Meta, Canvas, Story, ArgsTable} from '@storybook/addon-docs/blocks';
-
+import { faker }  from '@faker-js/faker'
+import {range} from 'lodash'
 import PTooltip from './PTooltip.vue';
 import {
     getTooltipArgTypes
 } from '@/data-display/tooltips/story-helpers';
+import {POSITIONS} from "@/data-display/tooltips/type"; import {PBadge} from "@";
 
 
 <Meta title='Data Display/Tooltips' parameters={{
@@ -16,16 +18,19 @@ import {
 
 export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
-    components: { PTooltip },
+    components: { PTooltip, PBadge },
     template: `
-    <div class="h-full w-full overflow p-8">
-        <p-tooltip
-            :tag="tag"
-            :contents="contents"
-            :position="position"
-            :options="options"
-        >Show Tooltip</p-tooltip>
-    </div>
+        <div class="h-full w-full overflow p-8">
+            <p-badge>
+                <p-tooltip  :tag="tag"
+                            :contents="contents"
+                            :position="position"
+                            :options="options"
+                >
+                    Show Tooltip
+                </p-tooltip>
+            </p-badge>
+        </div>
     `,
     setup() {
         return {
@@ -43,17 +48,46 @@ export const Template = (args, { argTypes }) => ({
 <Canvas>
     <Story name="Basic">
         {{
-            components: { PTooltip },
+            components: { PTooltip, PBadge },
             template: `
-    <div class="h-full w-full overflow p-8 text-center">
-        <p-tooltip contents="tooltip contents" position="top">Top</p-tooltip><br/><br/>
-        <p-tooltip contents="tooltip contents" position="bottom">Bottom</p-tooltip><br/><br/>
-        <p-tooltip contents="tooltip contents" position="left">Left</p-tooltip><br/><br/>
-        <p-tooltip contents="tooltip contents" position="right">Right</p-tooltip>
-    </div>
-    `,
+                <div class="h-full w-full overflow p-8 text-center">
+                    <p-badge>
+                        <p-tooltip :contents="contents" position="top">Top</p-tooltip>
+                    </p-badge>
+                </div>
+            `,
             setup() {
-                return {}
+                return {
+                    contents: range(10).map(() => faker.lorem.sentence(5)),
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Position
+
+<Canvas>
+    <Story name="Position">
+        {{
+            components: { PTooltip, PBadge },
+            template: `
+                <div class="h-full w-full overflow p-8 flex flex-wrap gap-2">
+                    <p-badge v-for="position in positions">
+                        <p-tooltip :contents="contents" :position="position">
+                                {{position}}
+                        </p-tooltip>
+                    </p-badge>
+                </div>
+            `,
+            setup() {
+                return {
+                    positions: Object.values(POSITIONS),
+                    contents: range(10).map(() => faker.lorem.sentence(5)),
+                }
             }
         }}
     </Story>

--- a/src/data-display/tooltips/story-helpers.ts
+++ b/src/data-display/tooltips/story-helpers.ts
@@ -6,7 +6,7 @@ export const getTooltipArgTypes = (): ArgTypes => ({
     tag: {
         name: 'tag',
         type: { name: 'string' },
-        description: 'root element tag',
+        description: 'Root element tag',
         defaultValue: 'span',
         table: {
             type: {

--- a/src/data-display/tooltips/type.ts
+++ b/src/data-display/tooltips/type.ts
@@ -1,7 +1,4 @@
 export const POSITIONS = {
-    auto: 'auto',
-    'auto-start': 'auto-start',
-    'auto-end': 'auto-end',
     top: 'top',
     'top-start': 'top-start',
     'top-end': 'top-end',


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [X] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [X] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [X] Updated Storybook documents
- [X] Tested with console

### Description
* Add tooltip position
* Change the style of tooltip

---

* tooltip의 position 추가
* tooltip의 스타일 변경


<img width="703" alt="image" src="https://user-images.githubusercontent.com/19162140/199170053-d04b2a65-a066-4a70-ad9f-cc87aafd0416.png">


### Things to Talk About
* With the tooltip library (version 2.0.2), there was a difficulty in finely customizing the position of the tooltip spigot. However, the library already provides a UI so that the content of the tooltip can be sufficiently delivered to users, such as responsive response, so we agreed not to customize it. If custom is required in the future, it is possible to respond by [upgrading the version of the library](https://floating-vue.starpad.dev/api/#skidding).

---

* 툴팁 라이브러리(2.0.2버전)으로 툴팁 꼭지의 위치를 세밀하게 커스텀 하는데 어려움이 있었습니다. 그러나 이미 라이브러리에서 반응형 대응 등 유저에게 툴팁의 내용을 충분히 전달 할 수 있게 UI를 제공 하고 잇어 커스텀 하지 않기로 협의했습니다. 추후 커스텀이 필요할 경우 해당 [라이브러리의 버전을 업그레이드](https://floating-vue.starpad.dev/api/#skidding)하면 대응 가능합니다.

