### PR TITLE
fix(p-search): fix dropdown style issue

### DIFF
--- a/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
+++ b/src/inputs/dropdown/query-search-dropdown/PQuerySearchDropdown.vue
@@ -228,8 +228,10 @@ export default defineComponent<QuerySearchDropdownProps>({
 .p-query-search-dropdown {
     @apply w-full relative;
     .p-search {
-        @apply text-sm font-normal;
-        padding: 0.25rem 0.5rem;
+        .input-container {
+            @apply text-sm font-normal;
+            padding: 0.25rem 0.5rem;
+        }
     }
     .input-set {
         display: inline-flex;

--- a/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
+++ b/src/inputs/dropdown/search-dropdown/PSearchDropdown.vue
@@ -520,16 +520,18 @@ export default defineComponent<SearchDropdownProps>({
 .p-search-dropdown {
     @apply w-full relative;
     .p-search {
-        @apply text-sm font-normal;
-        &.disabled {
-            @apply text-gray-300;
-            .dropdown-button {
-                cursor: default;
+        .input-container {
+            @apply text-sm font-normal;
+            &.disabled {
+                @apply text-gray-300;
+                .dropdown-button {
+                    cursor: default;
+                }
             }
-        }
-        &.focused:not(.disabled) {
-            .dropdown-button {
-                @apply text-secondary;
+            &.focused:not(.disabled) {
+                .dropdown-button {
+                    @apply text-secondary;
+                }
             }
         }
     }
@@ -574,21 +576,23 @@ export default defineComponent<SearchDropdownProps>({
 
     &.multi-selectable {
         .p-search {
-            @apply relative flex-wrap row-gap-1;
-            padding-right: 3rem;
-            padding-top: 0.25rem;
-            padding-bottom: 0.25rem;
+            .input-container {
+                @apply relative flex-wrap row-gap-1;
+                padding-right: 3rem;
+                padding-top: 0.25rem;
+                padding-bottom: 0.25rem;
 
-            .dropdown-button {
-                @apply absolute;
-                top: 0.1875rem;
-                right: 0.5rem;
-            }
-            > .delete-icon {
-                @apply absolute cursor-pointer;
-                right: 2rem;
-                top: 0.4375rem;
-                height: 100%;
+                .dropdown-button {
+                    @apply absolute;
+                    top: 0.1875rem;
+                    right: 0.5rem;
+                }
+                > .delete-icon {
+                    @apply absolute cursor-pointer;
+                    right: 2rem;
+                    top: 0.4375rem;
+                    height: 100%;
+                }
             }
         }
     }

--- a/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
+++ b/src/inputs/search/autocomplete-search/PAutocompleteSearch.vue
@@ -375,7 +375,9 @@ export default defineComponent<AutocompleteSearchProps>({
 .p-autocomplete-search {
     @apply w-full relative;
     .p-search {
-        @apply text-sm font-normal;
+        .input-container {
+            @apply text-sm font-normal;
+        }
     }
     .p-context-menu {
         @apply font-normal;

--- a/src/inputs/search/query-search/PQuerySearch.vue
+++ b/src/inputs/search/query-search/PQuerySearch.vue
@@ -201,7 +201,9 @@ export default defineComponent({
 .p-query-search {
     @apply w-full;
     .p-search {
-        @apply text-sm font-normal;
+        .input-container {
+            @apply text-sm font-normal;
+        }
     }
     .menu-container {
         @apply w-full relative;


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console

### Description
- Layout style issue in dropdown  where `p-search` is used. The cause was due to the layer added one more depth to the `p-search`.
- So, I added a layer to `.p-search` style injected from the dropdown.

--- 
- `p-search`가 사용되는 드롭다운에서 style 이슈가 발생했습니다. `p-search`가 수정되면서 레이어가 한 겹 추가된 것이 원인이었습니다.
- `p-search`를 사용하는 드롭다운에서 (`.p-search`를 사용해서 커스텀 스타일을 주입하는 곳에서) 한 겹을 추가하면서 해결하였습니다. 
- `.p-search {}` => `.p-search { .input-container{} }`

![image](https://user-images.githubusercontent.com/83635051/199869891-9ed934d4-10c9-4255-84fa-7add055c3463.png)
