### PR TITLE
feat(board): add column case in board `cards` type

### DIFF
--- a/src/data-display/board/PBoard.stories.mdx
+++ b/src/data-display/board/PBoard.stories.mdx
@@ -24,6 +24,7 @@ export const Template = (args, {argTypes}) => ({
             <p-board
                 :style-type="styleType"
                 :board-sets="boardItemList"
+                :style-options="styleOptions"
             >
                 <template #item-content>
                     <strong>Example Title</strong>
@@ -36,6 +37,7 @@ export const Template = (args, {argTypes}) => ({
         const state = reactive({
             boardItemList: computed(() => props.boardSets),
             styleType: computed(() => props.styleType),
+            styleOptions: computed(() => props.styleOptions),
             pageLimit: computed(() => props.pageLimit),
         });
         return {
@@ -48,6 +50,30 @@ export const Template = (args, {argTypes}) => ({
 
 <br/>
 <br/>
+
+## Style Type and Style Options
+
+Board component has two style props: `styleType` and `styleOptions`.<br/>
+`styleType` is the highest standard that determines the style of `Board`, and `styleOptions` is an option that each `styleType` has independently.<br/>
+In order to use `Board` component, it is first necessary to understand what `styleOptions` each `styleType` has.
+
+|Style Type|Style Options Properties|Description|
+|-|-|-|
+|`list`| - |It is not affected by any styleOptions.|
+|`cards`|`column`|In the cards type, Board Items have a user-defined number of columns. The default is 1.|
+
+<br/>
+
+### cards - styleOptions
+```
+interface StyleOptions {
+    column: number;
+}
+```
+
+<br/>
+<br/>
+
 
 ## Board Set Properties
 
@@ -161,7 +187,7 @@ Board's `boardSets` props is an `array` of `BoardSet`.
 <br/>
 <br/>
 
-## Style Type - Cards
+### Style Type - Cards
 
 The Board component receives an object type prop called `styleOptions`.<br/>
 In the `cards` type case, `styleOptions` takes the number of columns.<br/>
@@ -172,10 +198,10 @@ interface StyleOptions {
     column: number;
 }
 ```
+When no value is given to styleOptions, it defaults to 1 column.<br/>
 In screen **breakpoints below tablet (less than 1024px)**, the given number of columns is ignored and **only has one column**.
 
 
-<br/>
 <br/>
 
 <Canvas>

--- a/src/data-display/board/PBoard.stories.mdx
+++ b/src/data-display/board/PBoard.stories.mdx
@@ -3,7 +3,7 @@ import { i18n } from '@/translations';
 
 import { reactive, toRefs, computed } from 'vue';
 
-import {basicItemSets, boardStandardItemSets} from '@/data-display/board/mock';
+import { basicItemSets, boardStandardItemSets, cardsStyleOption } from '@/data-display/board/mock';
 import { getBoardArgTypes } from '@/data-display/board/story-helper';
 import PBoard from '@/data-display/board/PBoard';
 
@@ -149,6 +149,77 @@ Board's `boardSets` props is an `array` of `BoardSet`.
             setup() {
                 const state = reactive({
                     boardItemList: boardStandardItemSets,
+                });
+                return {
+                    ...toRefs(state),
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Style Type - Cards
+
+The Board component receives an object type prop called `styleOptions`.<br/>
+In the `cards` type case, `styleOptions` takes the number of columns.<br/>
+
+
+```
+interface StyleOptions {
+    column: number;
+}
+```
+In screen **breakpoints below tablet (less than 1024px)**, the given number of columns is ignored and **only has one column**.
+
+
+<br/>
+<br/>
+
+<Canvas>
+    <Story name="Style Type - Cards">
+        {{
+            i18n,
+            components: { PBoard },
+            template: `
+    <div class="h-full w-full overflow p-8">
+        <strong>Column : 2</strong>
+        <br/>
+        <br/>
+        <p-board
+            style-type="cards"
+            :board-sets="boardItemList"
+            :style-options="styleOptionsColumn2"
+        >
+            <template #item-content>
+                <strong>Example Title</strong>
+                <p>Any content can be here.</p>
+            </template>
+        </p-board>
+        <br/>
+        <br/>
+        <strong>Column : 3</strong>
+        <br/>
+        <br/>
+        <p-board
+            style-type="cards"
+            :board-sets="boardItemList"
+            :style-options="styleOptionsColumn3"
+        >
+            <template #item-content>
+                <strong>Example Title</strong>
+                <p>Any content can be here.</p>
+            </template>
+        </p-board>
+    </div>
+    `,
+            setup() {
+                const state = reactive({
+                    boardItemList: boardStandardItemSets,
+                    styleOptionsColumn2 : { column: 2 },
+                    styleOptionsColumn3 : { column: 3 },
                 });
                 return {
                     ...toRefs(state),

--- a/src/data-display/board/PBoard.vue
+++ b/src/data-display/board/PBoard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-board" :class="{ [`${styleType}-style`]: true }">
+    <div class="p-board" :class="[ [`${styleType}-style`], ...classByStyleOptions ]">
         <template v-for="(board, index) in boardList">
             <p-board-item :key="`board-${index}`"
                           class="p-board-item"
@@ -31,7 +31,7 @@ import type { PropType, SetupContext } from 'vue';
 
 import PBoardItem from '@/data-display/board-item/PBoardItem.vue';
 import { BOARD_STYLE_TYPE } from '@/data-display/board/type';
-import type { BoardProps, BoardSet } from '@/data-display/board/type';
+import type { BoardProps, BoardSet, StyleOptions } from '@/data-display/board/type';
 
 
 export default defineComponent<BoardProps>({
@@ -45,6 +45,10 @@ export default defineComponent<BoardProps>({
                 return Object.values(BOARD_STYLE_TYPE).includes(styleType);
             },
         },
+        styleOptions: {
+            type: Object as PropType<StyleOptions>,
+            default: undefined,
+        },
         boardSets: {
             type: Array as PropType<BoardSet[]>,
             default: () => [],
@@ -57,6 +61,16 @@ export default defineComponent<BoardProps>({
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             boardList: computed<BoardSet[]>(() => props.boardSets),
+            classByStyleOptions: computed(() => {
+                const classes: string[] = [];
+                if (!props.styleOptions) return classes;
+                if (BOARD_STYLE_TYPE.cards) {
+                    if (props.styleOptions.column) {
+                        classes.push(`lg:grid-cols-${props.styleOptions.column}`);
+                    }
+                }
+                return classes;
+            }),
         });
 
         const handleClickBoardItem = (item: BoardSet, index) => {
@@ -72,10 +86,8 @@ export default defineComponent<BoardProps>({
 </script>
 
 <style lang="postcss">
-.p-board {
-    @apply flex flex-col;
-}
 .list-style {
+    @apply flex flex-col;
     .p-board-item {
         @apply border-b-0;
     }
@@ -87,7 +99,8 @@ export default defineComponent<BoardProps>({
     }
 }
 .cards-style {
-    row-gap: 0.5rem;
+    @apply grid;
+    gap: 0.5rem;
     .p-board-item {
         @apply rounded-md;
     }

--- a/src/data-display/board/PBoard.vue
+++ b/src/data-display/board/PBoard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-board" :class="[ [`${styleType}-style`], ...classByStyleOptions ]">
+    <div class="p-board" :class="[ [`${styleType}-style`] ]" :style="{...inlineStylesByOptions}">
         <template v-for="(board, index) in boardList">
             <p-board-item :key="`board-${index}`"
                           class="p-board-item"
@@ -61,15 +61,15 @@ export default defineComponent<BoardProps>({
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             boardList: computed<BoardSet[]>(() => props.boardSets),
-            classByStyleOptions: computed(() => {
-                const classes: string[] = [];
-                if (!props.styleOptions) return classes;
+            inlineStylesByOptions: computed(() => {
+                const styles = {} as {[prop: string]: string};
+                if (!props.styleOptions) return styles;
                 if (BOARD_STYLE_TYPE.cards) {
                     if (props.styleOptions.column) {
-                        classes.push(`lg:grid-cols-${props.styleOptions.column}`);
+                        styles.gridTemplateColumns = `repeat(${props.styleOptions.column}, minmax(0, 1fr))`;
                     }
                 }
-                return classes;
+                return styles;
             }),
         });
 
@@ -103,6 +103,10 @@ export default defineComponent<BoardProps>({
     gap: 0.5rem;
     .p-board-item {
         @apply rounded-md;
+    }
+
+    @screen tablet {
+        grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
     }
 }
 </style>

--- a/src/data-display/board/PBoard.vue
+++ b/src/data-display/board/PBoard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-board" :class="[ [`${styleType}-style`] ]" :style="{...inlineStylesByOptions}">
+    <div class="p-board" :class="[ [`${styleType}-style`] ]" :style="styleVariableByOptions">
         <template v-for="(board, index) in boardList">
             <p-board-item :key="`board-${index}`"
                           class="p-board-item"
@@ -28,6 +28,7 @@ import {
     computed, defineComponent, reactive, toRefs,
 } from 'vue';
 import type { PropType, SetupContext } from 'vue';
+
 
 import PBoardItem from '@/data-display/board-item/PBoardItem.vue';
 import { BOARD_STYLE_TYPE } from '@/data-display/board/type';
@@ -61,17 +62,18 @@ export default defineComponent<BoardProps>({
     setup(props, { emit }: SetupContext) {
         const state = reactive({
             boardList: computed<BoardSet[]>(() => props.boardSets),
-            inlineStylesByOptions: computed(() => {
-                const styles = {} as {[prop: string]: string};
+            styleVariableByOptions: computed(() => {
+                const styles = {} as {[prop: string]: any};
                 if (!props.styleOptions) return styles;
                 if (BOARD_STYLE_TYPE.cards) {
                     if (props.styleOptions.column) {
-                        styles.gridTemplateColumns = `repeat(${props.styleOptions.column}, minmax(0, 1fr))`;
+                        styles['--columns'] = props.styleOptions.column;
                     }
                 }
                 return styles;
             }),
         });
+
 
         const handleClickBoardItem = (item: BoardSet, index) => {
             emit('item-click', item, index);
@@ -100,13 +102,16 @@ export default defineComponent<BoardProps>({
 }
 .cards-style {
     @apply grid;
+
+    --columns: 1;
     gap: 0.5rem;
+    grid-template-columns: repeat(var(--columns), minmax(0, 1fr));
     .p-board-item {
         @apply rounded-md;
     }
 
     @screen tablet {
-        grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
+        grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 }
 </style>

--- a/src/data-display/board/mock.ts
+++ b/src/data-display/board/mock.ts
@@ -1,5 +1,5 @@
 import { standardIconActionSet } from '@/data-display/board-item/mock';
-import type { BoardSet } from '@/data-display/board/type';
+import type { BoardSet, StyleOptions } from '@/data-display/board/type';
 
 export const basicItemSets: BoardSet[] = [
     {
@@ -62,3 +62,7 @@ export const boardStandardItemSets: BoardSet[] = [
         iconButtonSets: standardIconActionSet,
     },
 ];
+
+export const cardsStyleOption: StyleOptions = {
+    column: 3,
+};

--- a/src/data-display/board/story-helper.ts
+++ b/src/data-display/board/story-helper.ts
@@ -7,7 +7,7 @@ export const getBoardArgTypes = (): ArgTypes => ({
     styleType: {
         name: 'styleType',
         type: { name: 'string' },
-        description: `Card style types. [${Object.values(BOARD_STYLE_TYPE)}] are available`,
+        description: `Board style types. [${Object.values(BOARD_STYLE_TYPE)}] are available`,
         defaultValue: BOARD_STYLE_TYPE.list,
         table: {
             type: {
@@ -26,15 +26,15 @@ export const getBoardArgTypes = (): ArgTypes => ({
     styleOptions: {
         name: 'styleOptions',
         type: { name: 'object' },
-        description: "Card style type's options. Optional props",
-        defaultValue: undefined,
+        description: "Board style type's options. Each styleType has a different styleOptions. Optional props",
+        defaultValue: {},
         table: {
             type: {
                 summary: 'object',
             },
             category: 'props',
             defaultValue: {
-                summary: undefined,
+                summary: 'undefined',
             },
         },
     },

--- a/src/data-display/board/story-helper.ts
+++ b/src/data-display/board/story-helper.ts
@@ -23,6 +23,21 @@ export const getBoardArgTypes = (): ArgTypes => ({
             options: Object.values(BOARD_STYLE_TYPE),
         },
     },
+    styleOptions: {
+        name: 'styleOptions',
+        type: { name: 'object' },
+        description: "Card style type's options. Optional props",
+        defaultValue: undefined,
+        table: {
+            type: {
+                summary: 'object',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: undefined,
+            },
+        },
+    },
     boardSets: {
         name: 'boardSets',
         type: { name: 'array' },

--- a/src/data-display/board/type.ts
+++ b/src/data-display/board/type.ts
@@ -7,8 +7,13 @@ export const BOARD_STYLE_TYPE = {
 
 export type BOARD_STYLE_TYPE = typeof BOARD_STYLE_TYPE[keyof typeof BOARD_STYLE_TYPE];
 
+export interface StyleOptions {
+    column?: number;
+}
+
 export interface BoardProps {
     styleType?: BOARD_STYLE_TYPE;
+    styleOptions?: StyleOptions;
     boardSets: BoardItemProps[];
     pageLimit?: number;
 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- <del>[ ] Tested with console</del> 
- Currently, `npm link` does not work between console and mirinae
- **Please check on console with released mirinae**

### Description
Add column case in `list` board-type.
- Add optional `styleOptions` props.
- Update column case in Docs.
- The `styleOptions` are designed to be accepted in a slightly open way for the variety of board types to come.
---
`list` 타입의 Board에 column 케이스를 추가했습니다
- 선택적인 prop인 `styleOptions`를 추가했습니다.
- column 케이스에 해당하는 내용을 Docs에 업데이트 했습니다.
- `styleOptions`는 앞으로 다양한 Board 타입에 대응하기 위해 조금은 열린방식으로 설계했습니다.

![스크린샷 2022-11-21 오후 2 51 20](https://user-images.githubusercontent.com/83635051/202975310-792d52c0-879e-41b5-9ec1-377615150643.png)


### Think To Talk About
- The current styleOptions injection method requires users to be familiar with the method and that the properties used for each style are different. Is this a good way?
- Is it a good way to use tailwind css rather than inline style to inject styles?
```
  classByStyleOptions: computed(() => {
      const classes: string[] = [];
      if (!props.styleOptions) return classes;
      if (BOARD_STYLE_TYPE.cards) {
          if (props.styleOptions.column) {
              classes.push(`lg:grid-cols-${props.styleOptions.column}`);
          }
      }
      return classes;
  }),
```

---
- 현재 설계된 방식의 `styleOptions`를 이용하기 위해서 사용자는 각 스타일 타입마다 주입되는 속성이 다르다는 것을 인지해야합니다. 괜찮은 방법일까요..?
- `inlineStyle`이 아니라 `tailwindCSS`를 활용하고 있는데 이부분은 괜찮을까요?