### PR TITLE
fix(label): remove 'active' props & refactor class name

### DIFF
--- a/src/data-display/label/PLabel.stories.mdx
+++ b/src/data-display/label/PLabel.stories.mdx
@@ -23,7 +23,6 @@ export const Template = (args, {argTypes}) => ({
                      :left-icon="icon"
                      :deletable="deletable"
                      :clickable="clickable"
-                     :active="active"
                      :background-color="theme"
             />
         </div>
@@ -31,7 +30,6 @@ export const Template = (args, {argTypes}) => ({
     setup(props) {
         const state = reactive({
             text: computed(() => props.text),
-            active: computed(() => props.active),
             deletable: computed(() => props.deletable),
             clickable: computed(() => props.clickable),
             icon: computed(() => props.leftIcon),
@@ -60,14 +58,12 @@ export const Template = (args, {argTypes}) => ({
                     <div class="flex items-center">
                         <p-label text="Label"/>
                         <p-label text="Label" clickable/>
-                        <p-label text="Label" active/>
                         <p-label left-icon="ic_private" text="Label"/>
                     </div>
                     <br/>
                     <div class="flex items-center">
                         <p-label text="Label" deletable/>
                         <p-label text="Label" deletable clickable/>
-                        <p-label text="Label" deletable active/>
                         <p-label left-icon="ic_public" text="Label" deletable/>
                     </div>
                 </div>
@@ -121,7 +117,6 @@ export const Template = (args, {argTypes}) => ({
                 <div class="h-full w-full overflow p-8">
                     <p-label text="Label1" deletable/>
                     <p-label text="Label2" deletable clickable/>
-                    <p-label text="Label3" deletable active/>
                 </div>
             `
         }}

--- a/src/data-display/label/PLabel.vue
+++ b/src/data-display/label/PLabel.vue
@@ -1,11 +1,12 @@
 <template>
     <div class="p-label"
-         :class="{ clickable, active: proxyActive, 'icon-label': leftIcon }"
+         :class="{ clickable, 'icon-label': leftIcon }"
          @click.stop="handleClickLabel"
     >
         <span class="label-content">
             <slot name="label-content">
-                <p-i v-if="leftIcon" class="left-icon"
+                <p-i v-if="leftIcon"
+                     class="label-left-icon"
                      :name="leftIcon"
                      color="inherit"
                      width="0.75rem"
@@ -21,7 +22,7 @@
              name="ic_delete"
              width="1rem"
              height="1rem"
-             class="delete-icon"
+             class="label-delete-icon"
              color="inherit"
              @click.stop="$emit('delete')"
         />
@@ -29,11 +30,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, toRefs } from 'vue';
+import { defineComponent } from 'vue';
 import type { SetupContext } from 'vue';
 
 import PI from '@/foundation/icons/PI.vue';
-import { useProxyValue } from '@/hooks';
 
 interface LabelProps {
     leftIcon?: string;
@@ -71,17 +71,12 @@ export default defineComponent<LabelProps>({
         },
     },
     setup(props, { emit }: SetupContext) {
-        const state = reactive({
-            proxyActive: useProxyValue('active', props, emit),
-        });
-
         const handleClickLabel = () => {
             if (!props.clickable) return;
-            state.proxyActive = !state.proxyActive;
             emit('item-click');
         };
+
         return {
-            ...toRefs(state),
             handleClickLabel,
         };
     },
@@ -90,7 +85,7 @@ export default defineComponent<LabelProps>({
 
 <style lang="postcss">
 .p-label {
-    @apply bg-white rounded border border-gray-200;
+    @apply rounded border border-gray-200;
     display: inline-flex;
     align-items: center;
     height: 1.25rem;
@@ -106,18 +101,19 @@ export default defineComponent<LabelProps>({
         font-size: 0.75rem;
         line-height: normal;
     }
-    .left-icon {
+    .label-left-icon {
         width: 0.75rem;
         height: 0.75rem;
         margin-right: 0.125rem;
     }
-    .delete-icon {
+    .label-delete-icon {
         @apply text-gray-400;
         cursor: pointer;
         margin-left: 0.25rem;
     }
 
     &.clickable {
+        @apply bg-white;
         cursor: pointer;
 
         @media (hover: hover) {
@@ -128,12 +124,6 @@ export default defineComponent<LabelProps>({
                     @apply text-blue-600;
                 }
             }
-        }
-    }
-    &.active {
-        @apply bg-blue-200 border-blue-600;
-        .label-content {
-            @apply text-blue-600;
         }
     }
     &.icon-label {

--- a/src/data-display/label/story-helper.ts
+++ b/src/data-display/label/story-helper.ts
@@ -81,21 +81,21 @@ export const getLabelArgTypes = (): ArgTypes => ({
             },
         },
     },
-    active: {
-        name: 'active',
-        type: { name: 'boolean' },
-        description: 'The active status of label. This is the state when it is clicked in the clickable state.',
-        defaultValue: false,
-        table: {
-            type: {
-                summary: 'boolean',
-            },
-            category: 'props',
-            defaultValue: {
-                summary: 'false',
-            },
-        },
-    },
+    // active: {
+    //     name: 'active',
+    //     type: { name: 'boolean' },
+    //     description: 'The active status of label. This is the state when it is clicked in the clickable state.',
+    //     defaultValue: false,
+    //     table: {
+    //         type: {
+    //             summary: 'boolean',
+    //         },
+    //         category: 'props',
+    //         defaultValue: {
+    //             summary: 'false',
+    //         },
+    //     },
+    // },
     // events
     itemClick: {
         name: 'item-click',


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [ ] Tested with console(if usages are changed) 

### Description
Remove `active` props. 
- Because I misunderstood Clicked status of Label component and created it.

Change class name.
- Existing class name may overlap with another external class name.


Some update related to the background color of Label component will be made soon...