### PR TITLE
feat(select-dropdown): add v-bind in slot

### DIFF
--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -1,5 +1,6 @@
 <template>
-    <div v-click-outside="handleClickOutside" class="p-select-dropdown"
+    <div v-click-outside="handleClickOutside"
+         class="p-select-dropdown"
          :class="{
              [styleType] : true,
              invalid,
@@ -24,8 +25,12 @@
                 @click="handleClick"
                 @keydown.down="handlePressDownKey"
         >
-            <span class="text" :class="{placeholder: !$scopedSlots.default && !selectedItem}">
-                <slot name="default">
+            <span class="text"
+                  :class="{placeholder: !$scopedSlots.default && !selectedItem}"
+            >
+                <slot name="default"
+                      v-bind="selectedItem"
+                >
                     {{
                         selectedItem ?
                             (selectedItem.label || selectedItem.name || '') :
@@ -55,8 +60,12 @@
                         no-select-indication
                         @select="onSelectMenu"
         >
-            <template v-for="(_, slot) of menuSlots" #[slot]="scope">
-                <slot :name="`menu-${slot}`" v-bind="scope" />
+            <template v-for="(_, slot) of menuSlots"
+                      #[slot]="scope"
+            >
+                <slot :name="`menu-${slot}`"
+                      v-bind="scope"
+                />
             </template>
         </p-context-menu>
     </div>

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -29,7 +29,7 @@
                   :class="{placeholder: !$scopedSlots.default && !selectedItem}"
             >
                 <slot name="default"
-                      v-bind="selectedItem"
+                      v-bind="{item: selectedItem}"
                 >
                     {{
                         selectedItem ?

--- a/src/inputs/dropdown/select-dropdown/story-helper.ts
+++ b/src/inputs/dropdown/select-dropdown/story-helper.ts
@@ -243,7 +243,7 @@ export const getSelectDropdownArgTypes = (): ArgTypes => {
         ...contextMenuSlots,
         defaultSlot: {
             name: 'default',
-            description: 'Slot for dropdown button text. Default value is placeholder or selected item\'s label.',
+            description: 'Slot for dropdown button text. Default value is placeholder or selected item\'s label. Selected item will be given as slot props.',
             defaultValue: null,
             table: {
                 type: {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [x] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console(if usages are changed) 

### Description

Add v-bind in slot. 
It needs for expanding select dropdown. (Such as badge adding)

Only line34 has added. Others are results of eslint.

### Things to Talk About
