### PR TITLE
fix(p-lottie): lottie hasn't been loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "highlight.js": "^10.0.2",
         "linkify-it": "^4.0.1",
         "lodash": "^4.17.15",
-        "lottie-web": "^5.5.9",
+        "lottie-web": "5.10.0",
         "marked": "^4.0.10",
         "uuid": "^8.3.0",
         "v-click-outside": "^3.0.1",
@@ -30332,9 +30332,9 @@
       }
     },
     "node_modules/lottie-web": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.6.6.tgz",
-      "integrity": "sha512-N2c5+VjWFFEv8AQIDohFQaFiPudcSTSKE6WrMmUqtjc+/tQWe23eTu7XHqzXuAf7HDQclHhBorDeSelPNaYiHQ=="
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.10.0.tgz",
+      "integrity": "sha512-q2hfqKrGXNkwjSSZjKxf3fWMi0e3ZBc03qBkVWoGbwUJ7BcG+9YXjMPtmmhitzk8Nc6VQ5PRnh9yInPdfq0PZg=="
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -73414,9 +73414,9 @@
       }
     },
     "lottie-web": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.6.6.tgz",
-      "integrity": "sha512-N2c5+VjWFFEv8AQIDohFQaFiPudcSTSKE6WrMmUqtjc+/tQWe23eTu7XHqzXuAf7HDQclHhBorDeSelPNaYiHQ=="
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.10.0.tgz",
+      "integrity": "sha512-q2hfqKrGXNkwjSSZjKxf3fWMi0e3ZBc03qBkVWoGbwUJ7BcG+9YXjMPtmmhitzk8Nc6VQ5PRnh9yInPdfq0PZg=="
     },
     "lower-case": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "highlight.js": "^10.0.2",
     "linkify-it": "^4.0.1",
     "lodash": "^4.17.15",
-    "lottie-web": "^5.5.9",
+    "lottie-web": "5.10.0",
     "marked": "^4.0.10",
     "uuid": "^8.3.0",
     "v-click-outside": "^3.0.1",

--- a/src/foundation/lottie/PLottie.vue
+++ b/src/foundation/lottie/PLottie.vue
@@ -1,18 +1,21 @@
 <template>
     <div class="p-lottie">
-        <div ref="lottieRef" :style="{
-            height: height || `${size}rem`,
-            width: width || `${size}rem`,
-        }"
+        <div ref="lottieRef"
+             :style="{
+                 height: height || `${size}rem`,
+                 width: width || `${size}rem`,
+             }"
         />
     </div>
 </template>
 <script lang="ts">
+import type { WatchStopHandle } from 'vue';
 import {
     defineComponent, onMounted, onUnmounted, reactive, toRefs, watch,
 } from 'vue';
 
 import lottie from 'lottie-web';
+import type { AnimationItem } from 'lottie-web';
 
 import type { LottieProps } from '@/foundation/lottie/type';
 
@@ -58,12 +61,11 @@ export default defineComponent<LottieProps>({
     },
     setup(props: LottieProps) {
         const state = reactive({
-            animation: null as any,
-            lottieRef: null as any,
+            animation: null as null|AnimationItem,
+            lottieRef: null as null|HTMLDivElement,
             uuid: Math.floor(Math.random() * Date.now()).toString(),
         });
 
-        let stopWatch: any;
 
         const loadLottie = async () => {
             if (!state.lottieRef) return;
@@ -77,11 +79,12 @@ export default defineComponent<LottieProps>({
                     renderer: 'svg',
                     loop: true,
                     autoplay: true,
-                    animationData: lottieFile,
+                    animationData: lottieFile.default,
                 });
             }
         };
 
+        let stopWatch: WatchStopHandle;
         onMounted(async () => {
             stopWatch = watch(() => props.name, async (after) => {
                 if (after) await loadLottie();


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents
- [x] Tested with console(if usages are changed) 

### Description

Fix lottie not working after vite applied.

It was caused by `import()` operate has been changed. 
When importing assets (such as `.svg`, `.json` ...), need to access with `.default`
eg: `await import('.....').default`

Minor things
- Update `lottie-web` version to latest
- Improve types

### Things to Talk About
