### PR TITLE
refactor(context-menu): add menu container layer

### DIFF
--- a/src/hooks/context-menu-fixed-style/index.ts
+++ b/src/hooks/context-menu-fixed-style/index.ts
@@ -52,7 +52,7 @@ export const useContextMenuFixedStyle = ({ useFixedMenuStyle, visibleMenu }: Sta
         const targetRects: DOMRect = contextMenuFixedStyleState.targetElement?.getBoundingClientRect();
 
         const contextMenuStyle: Partial<CSSStyleDeclaration> = {
-            overflowY: 'auto',
+            // overflowY: 'auto',
             height: 'auto',
             minHeight: '32px',
         };

--- a/src/hooks/context-menu-fixed-style/index.ts
+++ b/src/hooks/context-menu-fixed-style/index.ts
@@ -72,7 +72,7 @@ export const useContextMenuFixedStyle = ({ useFixedMenuStyle, visibleMenu }: Sta
         } else {
             const height = targetRects.top - 12;
             contextMenuStyle.maxHeight = `${height < 0 ? 0 : height}px`;
-            if (state.useFixedMenuStyle) contextMenuStyle.bottom = `${targetRects.top}px`;
+            if (state.useFixedMenuStyle) contextMenuStyle.bottom = `calc(100vh - ${targetRects.top}px)`;
             else contextMenuStyle.bottom = `${targetRects.height}px`;
         }
 

--- a/src/inputs/context-menu/PContextMenu.stories.mdx
+++ b/src/inputs/context-menu/PContextMenu.stories.mdx
@@ -1,14 +1,17 @@
 import { Meta, Canvas, Story, ArgsTable, Description } from '@storybook/addon-docs/blocks';
 import { reactive, toRefs, watch } from 'vue';
+import {debounce} from "lodash";
+import { faker } from '@faker-js/faker';
 
 import PContextMenu from './PContextMenu.vue';
 import PEmpty from '@/data-display/empty/PEmpty';
 import PI from '@/foundation/icons/PI.vue';
 import PToggleButton from '@/inputs/buttons/toggle-button/PToggleButton';
+import PButton from "@/inputs/buttons/button/PButton.vue";
 import PTextEditor from "@/inputs/text-editor/PTextEditor";
 
 import {contextMenuSlots, getContextMenuArgTypes} from '@/inputs/context-menu/story-helper';
-import {menuItems, longMenuItems} from '@/inputs/context-menu/mock';
+import {menuItems, longMenuItems, getContextMenuItems} from '@/inputs/context-menu/mock';
 
 
 <Meta title='Inputs/Context Menu' parameters={{
@@ -552,6 +555,65 @@ It works only in multi select case.
 <br/>
 <br/>
 
+## Show More
+
+<Canvas>
+    <Story name="Show More" height={'18rem'}>
+        {{
+            components: { PContextMenu, PButton, PToggleButton},
+            template: `
+<div>
+    <div class="mb-4 flex gap-4 items-center">
+        <p-button style-type="secondary" @click="handleClickReset" >Reset</p-button>
+        <div>
+            Next items exist: <p-toggle-button :value="hasMore" @change="hasMore = !hasMore"/>
+        </div>
+    </div>
+    <p-context-menu :menu="menu" show-clear-selection multi-selectable
+        :loading="loading"
+        @click-show-more="handleClickShowMore"
+    />
+</div>
+`,
+    setup() {
+        const headerItem = {type: 'header', label: 'Names', name: 'names-header'};
+        const showMoreItem = {type: 'showMore', name: 'show-more'};
+        const state = reactive({
+            menu: [headerItem, ...getContextMenuItems(), showMoreItem],
+            loading: false,
+            hasMore: true
+        });
+        const handleClickReset = () => {
+         state.menu = [headerItem, ...getContextMenuItems(), showMoreItem]
+        }
+        const handleClickShowMore = async () => {
+            state.loading = true;
+            state.menu = await new Promise(resolve => {
+                setTimeout(() => {
+                    let items = state.menu;
+                    // remove show more item
+                    items.pop();
+                    // add menu items
+                    items = items.concat(getContextMenuItems());
+                    // append show more item if next items exist
+                    if (state.hasMore) items.push(showMoreItem);
+                    resolve(items)
+                }, 1000)
+            })
+            state.loading = false;
+        }
+        return {
+            ...toRefs(state),
+            handleClickReset,
+            handleClickShowMore
+        }
+    }
+}}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
 
 ## Playground
 

--- a/src/inputs/context-menu/PContextMenu.stories.mdx
+++ b/src/inputs/context-menu/PContextMenu.stories.mdx
@@ -176,7 +176,7 @@ Each `MenuItem` has the following type to represent it:
 ## Slots
 
 <Description markdown={`
-Context Menu have ${contextMenuSlots.length} slots:
+Context Menu have ${contextMenuSlots.length} slots: \n
 |Slot|Description|
 |-|-|
 ${contextMenuSlots.map(([name, description]) => `|${name}|${description}|`).join('\n')}

--- a/src/inputs/context-menu/PContextMenu.vue
+++ b/src/inputs/context-menu/PContextMenu.vue
@@ -319,8 +319,6 @@ export default defineComponent<ContextMenuProps>({
     > .menu-container {
         min-height: inherit;
         max-height: inherit;
-        min-width: inherit;
-        max-width: inherit;
         overflow-y: auto;
         > .selected-list-wrapper {
             @apply border-b border-gray-200;

--- a/src/inputs/context-menu/PContextMenu.vue
+++ b/src/inputs/context-menu/PContextMenu.vue
@@ -2,121 +2,124 @@
     <div class="p-context-menu"
          @keyup.esc="onClickEsc"
     >
-        <slot v-show="menu.length > 0"
-              name="menu"
-              v-bind="{...$props}"
-        >
-            <div v-if="showSelectHeader && multiSelectable"
-                 class="selected-list-wrapper"
-            >
-                <div>
-                    <b>{{ $t('COMPONENT.CONTEXT_MENU.SELECTED_LIST') }}</b>
-                    <span class="pl-2">({{ selectedCount }})</span>
-                </div>
-                <p-button size="sm"
-                          style-type="primary"
-                          :disabled="!proxySelected.length"
-                          @click="$emit('click-done', $event)"
-                >
-                    {{ $t('COMPONENT.CONTEXT_MENU.DONE') }}
-                </p-button>
-            </div>
-            <p-text-button v-if="showClearSelection && multiSelectable"
-                           class="clear-all-wrapper"
-                           style-type="highlight"
-                           size="sm"
-                           @click.stop="handleClickClearSelection"
-            >
-                {{ $t('COMPONENT.CONTEXT_MENU.CLEAR_SELECTION') }} ({{ selectedCount }})
-            </p-text-button>
-            <slot name="items">
-                <template v-for="(item, index) in menu">
-                    <p-context-menu-item v-if="item.type === undefined || item.type === 'item'"
-                                         :id="getItemId(index)"
-                                         :key="`item-${item.name}-${index}`"
-                                         :name="item.name"
-                                         :label="item.label"
-                                         :link="item.link"
-                                         :target="item.target"
-                                         :disabled="item.disabled"
-                                         :selected="!noSelectIndication && selectedNameMap[item.name] !== undefined"
-                                         :select-marker="multiSelectable ? 'checkbox' : (showRadioIcon ? 'radio' : undefined)"
-                                         :ellipsis="itemHeightFixed"
-                                         :highlight-term="highlightTerm"
-                                         :tabindex="index"
-                                         @click.stop="onClickMenu(item, index, $event)"
-                                         @keyup.enter="onClickMenu(item, index, $event)"
-                                         @keydown.up="onKeyUp(index)"
-                                         @keydown.down="onKeyDown(index)"
-                    >
-                        <template #default>
-                            <slot name="item--format"
-                                  v-bind="{...$props, item, index}"
-                            />
-                        </template>
-                        <template #text-list="{text, matched, textList, regex, index: textIndex}">
-                            <slot name="item-text-list"
-                                  v-bind="{...$props, item, index, text, matched, textList, regex, textIndex}"
-                            />
-                        </template>
-                    </p-context-menu-item>
-                    <div v-else-if="item.type==='divider'"
-                         :key="`divider-${index}`"
-                         class="context-divider"
-                    />
-                    <slot v-else-if="item.type==='header'"
-                          :name="`header-${item.name}`"
-                          v-bind="{...$props, item, key: index}"
-                    >
-                        <div :key="index"
-                             class="context-header"
-                        >
-                            {{ item.label }}
-                        </div>
-                    </slot>
-                    <div v-else-if="item.type === 'button'"
-                         :key="`button-${index}`"
-                         class="context-button"
-                         :class="{disabled: item.disabled}"
-                    >
-                        <p-button :disabled="item.disabled"
-                                  size="md"
-                                  style-type="secondary"
-                                  :block="true"
-                                  :icon-left="item.icon"
-                                  @click="$emit('click-button', item, index, $event)"
-                        >
-                            {{ item.label }}
-                        </p-button>
-                    </div>
-                    <div v-else-if="item.type === 'showMore'"
-                         :key="`show-more-${index}`"
-                         class="context-show-more"
-                    >
-                        <p-text-button style-type="highlight"
-                                       size="sm"
-                                       icon-right="ic_arrow_bottom"
-                                       @click="$emit('click-show-more', item, index, $event)"
-                        >
-                            {{ item.label ? item.label : $t('COMPONENT.CONTEXT_MENU.SHOW_MORE') }}
-                        </p-text-button>
-                    </div>
-                </template>
-            </slot>
-            <div v-if="$slots.bottom"
-                 class="bottom-slot-area"
-            >
-                <slot name="bottom" />
-            </div>
-        </slot>
-        <div v-show="menu.length === 0"
-             class="no-data"
-        >
-            <slot name="no-data-format"
+        <div class="menu-container">
+            <slot v-show="menu.length > 0"
+                  name="menu"
                   v-bind="{...$props}"
             >
-                {{ $t('COMPONENT.CONTEXT_MENU.NO_ITEM') }}
+                <div v-if="showSelectHeader && multiSelectable"
+                     class="selected-list-wrapper"
+                >
+                    <div>
+                        <b>{{ $t('COMPONENT.CONTEXT_MENU.SELECTED_LIST') }}</b>
+                        <span class="pl-2">({{ selectedCount }})</span>
+                    </div>
+                    <p-button size="sm"
+                              style-type="primary"
+                              :disabled="!proxySelected.length"
+                              @click="$emit('click-done', $event)"
+                    >
+                        {{ $t('COMPONENT.CONTEXT_MENU.DONE') }}
+                    </p-button>
+                </div>
+                <p-text-button v-if="showClearSelection && multiSelectable"
+                               class="clear-all-wrapper"
+                               style-type="highlight"
+                               size="sm"
+                               @click.stop="handleClickClearSelection"
+                >
+                    {{ $t('COMPONENT.CONTEXT_MENU.CLEAR_SELECTION') }} ({{ selectedCount }})
+                </p-text-button>
+                <slot name="items">
+                    <template v-for="(item, index) in menu">
+                        <p-context-menu-item v-if="item.type === undefined || item.type === 'item'"
+                                             :id="getItemId(index)"
+                                             :key="`item-${item.name}-${index}`"
+                                             :name="item.name"
+                                             :label="item.label"
+                                             :link="item.link"
+                                             :target="item.target"
+                                             :disabled="item.disabled"
+                                             :selected="!noSelectIndication && selectedNameMap[item.name] !== undefined"
+                                             :select-marker="multiSelectable ? 'checkbox' : (showRadioIcon ? 'radio' : undefined)"
+                                             :ellipsis="itemHeightFixed"
+                                             :highlight-term="highlightTerm"
+                                             :tabindex="index"
+                                             @click.stop="onClickMenu(item, index, $event)"
+                                             @keyup.enter="onClickMenu(item, index, $event)"
+                                             @keydown.up="onKeyUp(index)"
+                                             @keydown.down="onKeyDown(index)"
+                        >
+                            <template #default>
+                                <slot name="item--format"
+                                      v-bind="{...$props, item, index}"
+                                />
+                            </template>
+                            <template #text-list="{text, matched, textList, regex, index: textIndex}">
+                                <slot name="item-text-list"
+                                      v-bind="{...$props, item, index, text, matched, textList, regex, textIndex}"
+                                />
+                            </template>
+                        </p-context-menu-item>
+                        <div v-else-if="item.type==='divider'"
+                             :key="`divider-${index}`"
+                             class="context-divider"
+                        />
+                        <slot v-else-if="item.type==='header'"
+                              :name="`header-${item.name}`"
+                              v-bind="{...$props, item, key: index}"
+                        >
+                            <div :key="index"
+                                 class="context-header"
+                            >
+                                {{ item.label }}
+                            </div>
+                        </slot>
+                        <div v-else-if="item.type === 'button'"
+                             :key="`button-${index}`"
+                             class="context-button"
+                             :class="{disabled: item.disabled}"
+                        >
+                            <p-button :disabled="item.disabled"
+                                      size="md"
+                                      style-type="secondary"
+                                      :block="true"
+                                      :icon-left="item.icon"
+                                      @click="$emit('click-button', item, index, $event)"
+                            >
+                                {{ item.label }}
+                            </p-button>
+                        </div>
+                        <div v-else-if="item.type === 'showMore'"
+                             :key="`show-more-${index}`"
+                             class="context-show-more"
+                        >
+                            <p-text-button style-type="highlight"
+                                           size="sm"
+                                           icon-right="ic_arrow_bottom"
+                                           :disabled="loading"
+                                           @click="$emit('click-show-more', item, index, $event)"
+                            >
+                                {{ item.label ? item.label : $t('COMPONENT.CONTEXT_MENU.SHOW_MORE') }}
+                            </p-text-button>
+                        </div>
+                    </template>
+                </slot>
+                <div v-if="$slots.bottom"
+                     class="bottom-slot-area"
+                >
+                    <slot name="bottom" />
+                </div>
             </slot>
+            <div v-show="menu.length === 0"
+                 class="no-data"
+            >
+                <slot name="no-data-format"
+                      v-bind="{...$props}"
+                >
+                    {{ $t('COMPONENT.CONTEXT_MENU.NO_ITEM') }}
+                </slot>
+            </div>
         </div>
         <div v-show="loading"
              class="loader-wrapper"
@@ -309,53 +312,65 @@ export default defineComponent<ContextMenuProps>({
     text-align: left;
     background-clip: padding-box;
     max-height: 32rem;
-    overflow-y: auto;
     border-width: 1px;
     border-style: solid;
     user-select: none;
+    overflow: hidden;
+    > .menu-container {
+        min-height: inherit;
+        max-height: inherit;
+        min-width: inherit;
+        max-width: inherit;
+        overflow-y: auto;
+        > .selected-list-wrapper {
+            @apply border-b border-gray-200;
+            display: flex;
+            justify-content: space-between;
+            font-size: 0.875rem;
+            line-height: 1.5;
+            padding: 0.5rem;
+        }
+        > .clear-all-wrapper {
+            padding: 0.5rem 0.5rem 0.25rem 0.5rem;
+        }
+        > .context-header {
+            @apply text-gray-500;
+            margin-top: 0.875rem;
+            margin-bottom: 0.25rem;
+            padding-left: 0.5rem;
+            padding-right: 0.5rem;
+            font-weight: bold;
+            font-size: 0.75rem;
+            line-height: 1.5;
+        }
+        > .context-divider {
+            @apply border-t border-gray-200;
+            border-top-width: 1px;
+            border-top-style: solid;
+        }
+        > .context-button {
+            padding: 0.5rem;
 
-    > .selected-list-wrapper {
-        @apply border-b border-gray-200;
-        display: flex;
-        justify-content: space-between;
-        font-size: 0.875rem;
-        line-height: 1.5;
-        padding: 0.5rem;
-    }
-    > .clear-all-wrapper {
-        padding: 0.5rem 0.5rem 0.25rem 0.5rem;
-    }
-    > .context-header {
-        @apply text-gray-500;
-        margin-top: 0.875rem;
-        margin-bottom: 0.25rem;
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-        font-weight: bold;
-        font-size: 0.75rem;
-        line-height: 1.5;
-    }
-    > .context-divider {
-        @apply border-t border-gray-200;
-        border-top-width: 1px;
-        border-top-style: solid;
-    }
-    > .context-button {
-        padding: 0.5rem;
-
-        @media (hover: hover) {
-            &:hover:not(.disabled) {
-                @apply bg-blue-100;
+            @media (hover: hover) {
+                &:hover:not(.disabled) {
+                    @apply bg-blue-100;
+                }
             }
         }
-    }
-    > .context-show-more {
-        padding: 0.5rem;
-    }
-    > .bottom-slot-area {
-        padding: 0.5rem;
-    }
+        > .context-show-more {
+            padding: 0.5rem;
+        }
+        > .bottom-slot-area {
+            padding: 0.5rem;
+        }
 
+        > .no-data {
+            @apply text-gray-300;
+            padding: 0.5rem;
+            line-height: 1.25;
+            font-size: 0.875rem;
+        }
+    }
     > .loader-wrapper {
         @apply absolute w-full h-full overflow-hidden;
         top: 0;
@@ -370,12 +385,6 @@ export default defineComponent<ContextMenuProps>({
             z-index: 1;
             max-height: 16.875rem;
         }
-    }
-    > .no-data {
-        @apply text-gray-300;
-        padding: 0.5rem;
-        line-height: 1.25;
-        font-size: 0.875rem;
     }
 }
 </style>

--- a/src/inputs/context-menu/context-menu-item/PContextMenuItem.vue
+++ b/src/inputs/context-menu/context-menu-item/PContextMenuItem.vue
@@ -8,26 +8,38 @@
         <p-i v-if="selectIcon"
              class="select-marker"
              :name="selectIcon"
-             width="1em" height="1em"
+             width="1em"
+             height="1em"
         />
-        <span class="label-wrapper" :class="{ellipsis}">
+        <span class="label-wrapper"
+              :class="{ellipsis}"
+        >
             <p-text-highlighting v-if="highlightTerm && !$slots.default"
-                                 :text="label" :term="highlightTerm"
+                                 :text="label"
+                                 :term="highlightTerm"
                                  class="text"
                                  style-type="secondary"
             >
                 <template #default="textHighlightingSlotProps">
-                    <slot name="text-list" v-bind="{...textHighlightingSlotProps, ...$props}" />
+                    <slot name="text-list"
+                          v-bind="{...textHighlightingSlotProps, ...$props}"
+                    />
                 </template>
             </p-text-highlighting>
-            <span v-else class="text">
-                <slot name="default" v-bind="$props">
+            <span v-else
+                  class="text"
+            >
+                <slot name="default"
+                      v-bind="$props"
+                >
                     {{ label }}
                 </slot>
             </span>
-            <p-i v-if="link" name="ic_external-link"
+            <p-i v-if="link"
+                 name="ic_external-link"
                  class="external-link-icon"
-                 width="0.875rem" height="0.875rem"
+                 width="0.875rem"
+                 height="0.875rem"
             />
         </span>
     </component>
@@ -145,11 +157,9 @@ export default defineComponent<ContextMenuItemProps>({
 
 <style lang="postcss">
 .p-context-menu-item {
-    @apply text-gray-900;
+    @apply text-gray-900 text-label-md;
     display: flex;
     padding: 0.5rem;
-    line-height: 1.25;
-    font-size: 0.875rem;
     cursor: pointer;
     &:not(.disabled) {
         &:hover, &:focus {

--- a/src/inputs/context-menu/mock.ts
+++ b/src/inputs/context-menu/mock.ts
@@ -56,3 +56,8 @@ export const longMenuItems: MenuItem[] = [
         label: faker.lorem.sentence(30), name: 'google', link: 'https://www.google.com', target: '_blank',
     },
 ];
+
+export const getContextMenuItems = () => {
+    const items: MenuItem[] = faker.datatype.array(10).map(() => ({ name: faker.datatype.uuid(), label: faker.name.firstName() }));
+    return items;
+};

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
@@ -68,7 +68,7 @@ export const Template = (args, { argTypes }) => ({
 ## Default
 
 <Canvas>
-    <Story name="Basic">
+    <Story name="Basic" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -93,7 +93,7 @@ export const Template = (args, { argTypes }) => ({
 ## Disabled
 
 <Canvas>
-    <Story name="Disabled">
+    <Story name="Disabled" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -117,7 +117,7 @@ export const Template = (args, { argTypes }) => ({
 ## Invalid
 
 <Canvas>
-    <Story name="Invalid">
+    <Story name="Invalid" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -141,7 +141,7 @@ export const Template = (args, { argTypes }) => ({
 ## Button Style Type
 
 <Canvas>
-    <Story name="Button Style Type">
+    <Story name="Button Style Type" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -181,7 +181,7 @@ export const Template = (args, { argTypes }) => ({
 ## Size
 
 <Canvas>
-    <Story name="Size">
+    <Story name="Size" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -227,7 +227,7 @@ export const Template = (args, { argTypes }) => ({
 ## Read Only
 
 <Canvas>
-    <Story name="Read Only">
+    <Story name="Read Only" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -275,7 +275,7 @@ export const Template = (args, { argTypes }) => ({
 ## Icon Button Type
 
 <Canvas>
-    <Story name="Icon Button Type">
+    <Story name="Icon Button Type" height={'500px'}>
         {{
             i18n,
             components: {
@@ -323,7 +323,7 @@ export const Template = (args, { argTypes }) => ({
 ## Default Slot
 
 <Canvas>
-    <Story name="Default Slot">
+    <Story name="Default Slot" height={'500px'}>
         {{
             i18n,
             components: { PSelectDropdown },
@@ -349,7 +349,7 @@ export const Template = (args, { argTypes }) => ({
 ## Use Fixed Menu Style
 
 <Canvas>
-    <Story name="Use Fixed Menu Style" >
+    <Story name="Use Fixed Menu Style">
         {{
             components: { PSelectDropdown, PToggleButton },
             template: `

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -371,8 +371,10 @@ export default defineComponent<SelectDropdownProps>({
         width: auto;
         &.left {
             left: 0;
+            right: unset;
         }
         &.right {
+            left: unset;
             right: 0;
         }
     }

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -412,6 +412,7 @@ export const Template = (args, { argTypes }) => ({
             `,
             setup() {
                 const state = reactive({
+                    value: '',
                     sizes: Object.values(INPUT_SIZE)
                 })
                 return {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [x] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents
- [x] Tested with console(if usages are changed) 

### Description

- Internal elements of context-menu are wrapped in 'main-container' <div>, and only 'loading-wrapper' <div> is placed in the same hierarchy. 
  - The reason for this was that the 'loading-wrapper' did not cover the scroll area when the number of menu items increased, so the HTML hierarchy had to be changed.
  - Checked side effects and fixed issues. all used components and console.
  - To check this problem, added 'Show More' story.
  
https://user-images.githubusercontent.com/26986739/208686776-f53e4cb1-029c-4600-99d1-710e27d95061.mov


### Things to Talk About
