### PR TITLE
fix(button-modal): fix alert theme header style

### DIFF
--- a/src/feedbacks/modals/button-modal/PButtonModal.vue
+++ b/src/feedbacks/modals/button-modal/PButtonModal.vue
@@ -1,11 +1,14 @@
 <template>
     <section class="p-button-modal">
-        <transition v-if="visible" name="modal">
+        <transition v-if="visible"
+                    name="modal"
+        >
             <div class="modal-mask"
                  :class="[{'no-backdrop':!backdrop}, {'absolute': !!absolute}]"
                  :style="absolute ? [{'top': `${absolute}rem`}, {'left': `${absolute}rem`}] : {}"
             >
-                <div class="modal-wrapper" :class="dialogClassObject"
+                <div class="modal-wrapper"
+                     :class="dialogClassObject"
                      role="dialog"
                      aria-modal="true"
                      aria-labelledby="headerTitle"
@@ -16,29 +19,42 @@
                              :style="absolute ? {'max-height': `calc(100vh - 4rem - ${absolute}rem`} : {}"
                     >
                         <h3 class="header">
-                            <slot v-if="!hideHeader" name="header">
-                                <div class="modal-header">
-                                    <span class="alert-icon">
-                                        <p-lottie name="lottie_error" auto :size="1.5"
-                                                  :class="[`modal-${themeColor}`]" class="header-lottie"
-                                        />
-                                    </span>
-                                    <span>{{ headerTitle }}</span>
+                            <slot v-if="!hideHeader"
+                                  name="header"
+                            >
+                                <div class="modal-header"
+                                     :class="[`${themeColor}-header`]"
+                                >
+                                    <p-lottie name="lottie_error"
+                                              auto
+                                              :size="1.5"
+                                              :class="[`modal-${themeColor}`]"
+                                              class="header-lottie"
+                                    />
+                                    {{ headerTitle }}
                                 </div>
                             </slot>
                             <p-icon-button v-if="!hideHeaderCloseButton"
-                                           name="ic_delete" color="inherit"
+                                           name="ic_delete"
+                                           color="inherit"
                                            class="close-button"
                                            :class="[{disabled: loading},
                                                     {'no-footer': hideFooter}]"
                                            @click.stop="onCloseClick"
                             />
                         </h3>
-                        <div v-if="!hideBody" class="modal-body" :class="allBodyClass">
+                        <div v-if="!hideBody"
+                             class="modal-body"
+                             :class="allBodyClass"
+                        >
                             <slot name="body" />
                         </div>
-                        <div v-if="!hideFooter" class="modal-footer">
-                            <slot :slot-scope="$props" name="footer-extra" />
+                        <div v-if="!hideFooter"
+                             class="modal-footer"
+                        >
+                            <slot :slot-scope="$props"
+                                  name="footer-extra"
+                            />
                             <p-button
                                 v-if="footerResetButtonVisible"
                                 class="modal-button reset-button"
@@ -46,7 +62,9 @@
                                 :disabled="loading"
                                 @click="onResetClick"
                             >
-                                <slot :slot-scope="$props" name="reset-button">
+                                <slot :slot-scope="$props"
+                                      name="reset-button"
+                                >
                                     Reset
                                 </slot>
                             </p-button>
@@ -56,7 +74,9 @@
                                       :disabled="loading"
                                       @click="onCancelClick"
                             >
-                                <slot name="close-button" v-bind="$props">
+                                <slot name="close-button"
+                                      v-bind="$props"
+                                >
                                     {{ $t('COMPONENT.BUTTON_MODAL.CANCEL') }}
                                 </slot>
                             </p-button>
@@ -69,7 +89,9 @@
                                 :disabled="disabled"
                                 @click="onConfirmClick"
                             >
-                                <slot name="confirm-button" v-bind="$props">
+                                <slot name="confirm-button"
+                                      v-bind="$props"
+                                >
                                     {{ $t('COMPONENT.BUTTON_MODAL.CONFIRM') }}
                                 </slot>
                             </p-button>
@@ -266,13 +288,15 @@ export default defineComponent<ButtonModalProps>({
             justify-content: space-between;
 
             .modal-header {
+                @apply text-display-sm;
                 display: flex;
                 align-items: flex-start;
                 min-height: $header-height;
-                font-size: 1.375rem;
-                line-height: 145%;
-                .alert-icon {
-                    padding-top: 0.25rem;
+                margin-bottom: 0.375rem;
+
+                &.alert-header {
+                    @apply relative;
+                    text-indent: 2rem;
                 }
             }
 
@@ -280,8 +304,8 @@ export default defineComponent<ButtonModalProps>({
                 display: none;
 
                 &.modal-alert {
-                    display: inline-flex;
-                    margin-right: 0.5rem;
+                    display: block;
+                    position: absolute;
                 }
             }
 


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [ ] Tested with console(if usages are changed) 

### Description
SSIA

- In alert theme, Header layout with lottie is changed.
- Previously, header text and lottie was different block. But, now looks like same block in case of header with 2 or more lines.

Before
![image](https://user-images.githubusercontent.com/83635051/210496965-2bdb1128-4840-4c2d-b81a-41f1125c2d30.png)

After
![image](https://user-images.githubusercontent.com/83635051/210496474-4a2a9b4f-3a41-478e-bba3-9815f4d317ba.png)

