### PR TITLE
BREAKING CHANGE: update filterable-dropdown features and styles

### DIFF
--- a/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.stories.mdx
+++ b/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.stories.mdx
@@ -7,7 +7,10 @@ import PButton from '@/inputs/buttons/button/PButton';
 import PToggleButton from '@/inputs/buttons/toggle-button/PToggleButton';
 
 import { getFilterableDropdownArgTypes } from '@/inputs/dropdown/filterable-dropdown/story-helper';
-import { getSearchDropdownMenu, getSearchDropdownMenuWithMultiTypes } from '@/inputs/dropdown/filterable-dropdown/mock';
+import {
+    getFilterableDropdownMenu,
+    getFilterableDropdownMenuWithMultiTypes,
+} from '@/inputs/dropdown/filterable-dropdown/mock';
 
 
 <Meta title='Inputs/Dropdown/Filterable Dropdown' parameters={{
@@ -25,35 +28,35 @@ export const Template = (args, { argTypes }) => ({
         <p-filterable-dropdown
             :menu="menu"
             :loading="loading"
-            :type="type"
-            :placeholder="proxyPlaceholder"
-            :disable-handler="disableHandler"
-            :exact-mode="exactMode"
-            :use-fixed-menu-style="useFixedMenuStyle"
-            :visible-menu.sync="proxyVisibleMenu"
             :selected.sync="proxySelected"
-            :strict-select-mode="strictSelectMode"
+            :multi-selectable="multiSelectable"
+            :search-text="proxySearchText"
+            :readonly="readonly"
+            :show-select-header="showSelectHeader"
+            :show-select-marker="showSelectMarker"
+            :visible-menu.sync="proxyVisibleMenu"
+            :use-fixed-menu-style="useFixedMenuStyle"
+            :placeholder="placeholder"
             :invalid="invalid"
             :disabled="disabled"
-            :multi-selectable="multiSelectable"
-            :disable-delete-all="disableDeleteAll"
-            @search="onSearch"
-            @focus="onFocus"
-            @blur="onBlur"
-            @input="onInput"
-            @delete="onDelete"
-            @hide-menu="onHideMenu"
-            @show-menu="onShowMenu"
-            @focus-menu="onFocusMenu"
-            @select-menu="onSelectMenu"
+            :handler="handler"
+            :disable-handler="disableHandler"
+            :appearance-type="appearanceType"
+            :page-size="pageSize"
+            @update:visible-menu="onUpdateVisibleMenu"
+            @update:search-text="onUpdateSearchText"
+            @update:selected="onUpdateSelected"
+            @select="onSelect"
+            @delete-tag="onDeleteTag"
+            @click-show-more="onClickShowMore"
         >
         </p-filterable-dropdown>
     `,
     setup(props, {emit}) {
         const state = reactive({
-            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
             proxySelected: useProxyValue('selected', props, emit),
-            proxyPlaceholder: useProxyValue('placeholder', props, emit),
+            proxySearchText: useProxyValue('searchText', props, emit),
+            proxyVisibleMenu: useProxyValue('visibleMenu', props, emit),
         })
         return {
             ...toRefs(state)
@@ -69,12 +72,12 @@ export const Template = (args, { argTypes }) => ({
 ## Basic
 
 <Canvas>
-    <Story name="Basic" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
+    <Story name="Basic" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
         {{
             props: Object.keys(getFilterableDropdownArgTypes()),
             components: { PFilterableDropdown },
             template: `
-<div class="h-full w-full overflow p-8">
+<div>
         <p-filterable-dropdown :menu="menu"  />
 </div>
 `,
@@ -85,15 +88,28 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
-## With Header
+## Show Select Marker
 
 <Canvas>
-    <Story name="With Header" args={{menu: getSearchDropdownMenuWithMultiTypes()}} height={'400px'}>
+    <Story name="Show Select Marker" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
         {{
             props: Object.keys(getFilterableDropdownArgTypes()),
-            components: { PFilterableDropdown, PButton },
+            components: { PFilterableDropdown },
             template: `
-        <p-filterable-dropdown :menu="menu" />
+        <div>
+            <p class="text-label-lg font-bold my-3">Single select without marker</p>
+            <p-filterable-dropdown :menu="menu" />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Single select with marker</p>
+            <p-filterable-dropdown :menu="menu" show-select-marker />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Multi select without marker</p>
+            <p-filterable-dropdown :menu="menu" multi-selectable />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Multi select with marker</p>
+            <p-filterable-dropdown :menu="menu" multi-selectable show-select-marker />
+            <br/>
+        </div>
 `,
         }}
     </Story>
@@ -102,43 +118,266 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
-## Using Handler
+## Appearance Type
 
 <Canvas>
-    <Story name="Using Handler" height={'400px'}>
+    <Story name="Appearance Type" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
         {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
+            components: { PFilterableDropdown },
+            template: `
+        <div>
+            <p class="text-label-lg font-bold my-3">Single select with 'basic', 'badge', 'stack' appearance type</p>
+            <p-filterable-dropdown :menu="menu" :selected.sync="singleSelected" />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Single selected: </p>
+            <pre>{{ singleSelected }}</pre>
+            <br/>
+            <hr/>
+            <br/>
+            <p class="text-label-lg font-bold my-3">Multi select with 'basic' appearance type</p>
+            <p-filterable-dropdown :menu="menu":selected.sync="multiSelected"  multi-selectable />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Multi select with 'badge' appearance type</p>
+            <p-filterable-dropdown :menu="menu" :selected.sync="multiSelected" multi-selectable appearance-type="badge" />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Multi select with 'stack' appearance type</p>
+            <p-filterable-dropdown :menu="menu" :selected.sync="multiSelected" multi-selectable appearance-type="stack" />
+            <br/>
+            <p class="text-label-lg font-bold my-3">Multi selected: </p>
+            <pre>{{ multiSelected }}</pre>
+            <br/>
+        </div>
+`,
+            setup(props) {
+                const state = reactive({
+                    singleSelected: [props.menu.find(d => !d.type || d.type === 'item')],
+                    multiSelected: props.menu.filter(d => !d.type || d.type === 'item').splice(0, 15),
+                })
+                return {
+                    ...toRefs(state)
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+
+## Show Select Header
+
+<Canvas>
+    <Story name="Show Select Header" args={{menu: getFilterableDropdownMenuWithMultiTypes()}} height={'400px'}>
+        {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
             components: { PFilterableDropdown, PButton },
             template: `
-            <p-filterable-dropdown :loading="loading" :handler="simpleHandler" />
+            <div>
+                <p class="text-label-lg font-bold my-3">Multi select without select header</p>
+                <p-filterable-dropdown :menu="menu"  multi-selectable />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Multi select with select header</p>
+                <p-filterable-dropdown :menu="menu" multi-selectable show-select-header />
+                <br/>
+            </div>
+`,
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Using Custom Handler & Loading
+
+Use a handler to show the menu with the return value. <br/>
+So with custom handler, there is no need to give menu prop. <br/>
+
+You can control loading manually by loading prop. <br/>
+If you don't give loading prop, loading UI will be displayed automatically when handler is running. <br/>
+
+Handler type:
+
+```typescript
+interface HandlerRes {
+    results: MenuItem[]; // this is context menu items
+    totalCount?: number; // will be deprecated
+    more?: boolean; // Whether to show 'show more' item on the bottom or not
+}
+interface AutocompleteHandler {
+    (inputText: string, pageStart?: number, pageLimit?: number): Promise<HandlerRes>|HandlerRes;
+}
+```
+
+
+<Canvas>
+    <Story name="Using Custom Handler & Loading" args={{menu: getFilterableDropdownMenuWithMultiTypes()}} height={'400px'}>
+        {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
+            components: { PFilterableDropdown, PButton },
+            template: `
+            <div>
+                <p class="text-label-lg font-bold my-3">Without custom handler(use default handler internally)</p>
+                <p-filterable-dropdown :loading="loading" :menu="menu"  />
+                <br/>
+                <p class="text-label-lg font-bold my-3">With custom handler</p>
+                <p-filterable-dropdown :handler="simpleHandler" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">With custom handler and loading</p>
+                <p-filterable-dropdown :loading="loading" :handler="simpleHandler" />
+                <br/>
+            </div>
 `,
             setup() {
                 const state = reactive({
                     loading: false,
                 })
-                const menu = getSearchDropdownMenuWithMultiTypes()
+                const menu = getFilterableDropdownMenuWithMultiTypes()
+                let allResults = []
                 const simpleHandler = async (inputText) => {
                     state.loading = true;
-                    const results = await new Promise(resolve => {
+                    allResults = await new Promise(resolve => {
                         setTimeout(() => {
-                            let results = [...menu];
+                            let filtered;
                             const trimmed = inputText.trim();
                             if (trimmed) {
-                                results = new Fuse(results, {
+                                filtered = new Fuse(menu, {
                                     keys: ['label'],
                                     distance: 100,
                                     threshold: 0.1,
                                     ignoreLocation: true,
                                 }).search(trimmed);
+                            } else {
+                                filtered = [...menu]
                             }
-                            resolve(results)
+                            resolve(filtered)
                         }, 500)
                     })
                     state.loading = false;
-                    return { results }
+                    const results = allResults.slice(0, 5)
+                    return { results, more: allResults.length > results.length }
                 }
                 return {
                     ...toRefs(state),
                     simpleHandler
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Show More & Page Size
+
+When using the `handler` prop, the first argument of the handler is the input text, the second argument is the pageStart value, and the third argument is the pageLimit. <br/>
+pageStart and pageLimit are calculated based on the value given to the `pageSize` prop. <br/>
+
+For example, if `pageSize` is 5, pageStart is initially given 1 and pageLimit is given 5. <br/>
+If the value of more in the result of executing the handler is true, the show more button is displayed. <br/>
+When the user presses the show more button, the handler runs again. <br/>
+At this time, 6 is given as the value of the pageStart argument and 10 is given as the value of the pageLimit argument. <br/>
+
+<Canvas>
+    <Story name="Show More & Page Size" args={{menu: getFilterableDropdownMenu(11, 22)}} height={'400px'}>
+        {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
+            components: { PFilterableDropdown, PButton },
+            template: `
+            <div>
+                <p class="text-label-lg font-bold my-3">Without custom handler, with page size 5</p>
+                <p-filterable-dropdown :loading="loading" :menu="menu" :page-size="5" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">With custom handler, with page size 5</p>
+                <p-filterable-dropdown :handler="simpleHandler" :page-size="5" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Disable handler, with page size 5</p>
+                <p-filterable-dropdown :menu="menu" disable-handler :page-size="5" />
+                <br/>
+            </div>
+`,
+            setup() {
+                const state = reactive({
+                    loading: false,
+                })
+                const simpleHandler = async (inputText, pageStart, pageLimit) => {
+                    state.loading = true;
+                    const results = await new Promise(resolve => {
+                        setTimeout(() => {
+                            resolve(getFilterableDropdownMenu(5, 5, inputText))
+                        }, 500)
+                    })
+                    state.loading = false;
+                    return { results, more: pageLimit < 15 }
+                }
+                return {
+                    ...toRefs(state),
+                    simpleHandler,
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Disable Handler
+
+As you enter values into the search input, the menu is filtered by default handler. <br/>
+If you don't want to use this feature, give true to the disableHandler prop.
+
+<Canvas>
+    <Story name="Disable Handler" args={{menu: getFilterableDropdownMenuWithMultiTypes()}} height={'400px'}>
+        {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
+            components: { PFilterableDropdown, PButton },
+            template: `
+            <div>
+                <p class="text-label-lg font-bold my-3">With default handler </p>
+                <p-filterable-dropdown :menu="menu" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Disable handler </p>
+                <p-filterable-dropdown :menu="menu" disable-handler />
+                <br/>
+            </div>
+`,
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Readonly & Disabled
+
+<Canvas>
+    <Story name="Readonly & Disabled" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
+        {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
+            components: { PFilterableDropdown },
+            template: `
+            <div>
+                <p class="text-label-lg font-bold my-3">Normal</p>
+                <p-filterable-dropdown :menu="menu" :selected.sync="selected"  />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Disabled</p>
+                <p-filterable-dropdown :menu="menu" :selected.sync="selected" disabled />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Readonly</p>
+                <p-filterable-dropdown :menu="menu" :selected.sync="selected" readonly />
+                <br/>
+            </div>
+`,
+            setup(props) {
+                const state = reactive({
+                    selected: [props.menu.find(d => !d.type || d.type === 'item')],
+                })
+                return {
+                    ...toRefs(state)
                 }
             }
         }}
@@ -169,7 +408,7 @@ export const Template = (args, { argTypes }) => ({
 `,
             setup() {
                 const state = reactive({
-                    menu: getSearchDropdownMenu(30, 50),
+                    menu: getFilterableDropdownMenu(30, 50),
                     useFixedMenuStyle: true,
                     show: true
                 })
@@ -195,174 +434,55 @@ export const Template = (args, { argTypes }) => ({
 ## Invalid
 
 <Canvas>
-    <Story name="Invalid" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
+    <Story name="Invalid" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
         {{
             props: Object.keys(getFilterableDropdownArgTypes()),
             components: { PFilterableDropdown },
             template: `
-        <p-filterable-dropdown :menu="menu" invalid />
+            <div>
+                <p class="text-label-lg font-bold my-3">Normal</p>
+                <p-filterable-dropdown :menu="menu" :selected.sync="selected"  />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Invalid</p>
+                <p-filterable-dropdown :menu="menu" :selected.sync="selected" invalid />
+                <br/>
+            </div>
 `,
-        }}
-    </Story>
-</Canvas>
-
-<br/>
-<br/>
-
-## Disabled
-
-<Canvas>
-    <Story name="Disabled" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
-        {{
-            props: Object.keys(getFilterableDropdownArgTypes()),
-            components: { PFilterableDropdown },
-            template: `
-        <p-filterable-dropdown :menu="menu" disabled />
-`,
-        }}
-    </Story>
-</Canvas>
-
-<br/>
-<br/>
-
-## Readonly
-
-<Canvas>
-    <Story name="Readonly" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
-        {{
-            props: Object.keys(getFilterableDropdownArgTypes()),
-            components: { PFilterableDropdown },
-            template: `
-        <p-filterable-dropdown
-            :menu="menu"
-            :readonly="true"
-            type="radioButton"
-        />
-`,
-        }}
-    </Story>
-</Canvas>
-
-<br/>
-<br/>
-
-
-## Radio Button Type
-
-<Canvas>
-    <Story name="Radio Button Type" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
-        {{
-            props: Object.keys(getFilterableDropdownArgTypes()),
-            components: { PFilterableDropdown },
-            template: `
-        <p-filterable-dropdown :menu="menu" type="radioButton" />
-`,
-        }}
-    </Story>
-</Canvas>
-
-<br/>
-<br/>
-
-## Multi Selectable
-
-<Canvas>
-    <Story name="Multi Selectable" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
-        {{
-            props: Object.keys(getFilterableDropdownArgTypes()),
-            components: { PFilterableDropdown },
-            template: `
-        <p-filterable-dropdown :menu="menu" :multi-selectable="true" />
-`,
-        }}
-    </Story>
-</Canvas>
-
-<br/>
-<br/>
-
-## Multi Selectable With no Delete All Button
-
-<Canvas>
-    <Story name="Multi Selectable With no Delete All Button" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
-        {{
-            props: Object.keys(getFilterableDropdownArgTypes()),
-            components: { PFilterableDropdown },
-            template: `
-        <p-filterable-dropdown :menu="menu" :multi-selectable="true" :disable-delete-all="true" />
-`,
-        }}
-    </Story>
-</Canvas>
-
-<br/>
-<br/>
-
-## Strict Select Mode
-
-<Canvas>
-    <Story name="Strict Select Mode" height={'400px'}>
-        {{
-            components: { PFilterableDropdown, PToggleButton },
-            template: `
-    <div>
-        <p class="mb-2">
-            Use Strict Select Mode: <strong> {{strictSelectMode ? 'On' : 'Off' }}</strong> <p-toggle-button :value="strictSelectMode" @change="onChange" />
-        </p>
-        <div class=m-4>
-            <p class="m-2">default type</p>
-            <p-filterable-dropdown
-                :key="strictSelectMode ? 'strict-default' : 'default-default'"
-                :menu="menu"
-                :selected="defaultSelected"
-                :strict-select-mode="strictSelectMode"
-            />
-        </div>
-        <div class=m-4>
-            <p class="m-2">radioButton type</p>
-            <p-filterable-dropdown
-                :key="strictSelectMode ? 'strict-radio' : 'default-radio'"
-                :menu="menu"
-                type="radioButton"
-                :selected="radioSelected"
-                :strict-select-mode="strictSelectMode"
-            />
-        </div>
-        <div class=m-4>
-            <p class="m-2">multi selectable</p>
-            <p-filterable-dropdown
-                :key="strictSelectMode ? 'strict-checkbox' : 'default-checkbox'"
-                :menu="menu"
-                :multi-selectable="true"
-                :selected="checkboxSelected"
-                :strict-select-mode="strictSelectMode"
-            />
-        </div>
-    </div>
-`,
-            setup() {
-                const existItem = {name: 'exist in menu items', label: 'This item is exist in menu items'}
-                const notExistItem = {name: 'not in menu items', label: 'This item is not in menu items'}
-                const longItem = {name: 'long text item', label: 'This is long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item long text Item'}
+            setup(props) {
                 const state = reactive({
-                    menu: [...getSearchDropdownMenu(), existItem, longItem],
-                    defaultSelected: [notExistItem],
-                    radioSelected: [notExistItem],
-                    checkboxSelected: [notExistItem, existItem],
-                    strictSelectMode: false
+                    selected: [props.menu.find(d => !d.type || d.type === 'item')],
                 })
-                const onChange = () => {
-                    state.checkboxSelected = [notExistItem, existItem];
-                    state.defaultSelected = [notExistItem]
-                    state.radioSelected = [notExistItem]
-                    state.strictSelectMode = !state.strictSelectMode
-                }
                 return {
-                    ...toRefs(state),
-                    onChange
+                    ...toRefs(state)
                 }
             }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Placeholder
+
+<Canvas>
+    <Story name="Placeholder" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
+        {{
+            props: Object.keys(getFilterableDropdownArgTypes()),
+            components: { PFilterableDropdown },
+            template: `
+            <div>
+                <p class="text-label-lg font-bold my-3">Default placeholder for single select</p>
+                <p-filterable-dropdown :menu="menu" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Default placeholder for multi select</p>
+                <p-filterable-dropdown :menu="menu" multi-selectable />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Custom placeholder</p>
+                <p-filterable-dropdown :menu="menu" placeholder="Please Select One 😄" />
+                <br/>
+            </div>
+`,
         }}
     </Story>
 </Canvas>
@@ -373,10 +493,10 @@ export const Template = (args, { argTypes }) => ({
 ## Playground
 
 <Canvas>
-    <Story name="playground" args={{menu: getSearchDropdownMenu()}} height={'400px'}>
+    <Story name="Playground" args={{menu: getFilterableDropdownMenu()}} height={'400px'}>
         {Template.bind({})}
     </Story>
 </Canvas>
 
-<ArgsTable story="playground"/>
+<ArgsTable story="Playground"/>
 

--- a/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
+++ b/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
@@ -1,109 +1,81 @@
 <template>
-    <div v-on-click-outside="forceHideMenu"
+    <div v-on-click-outside="hideMenu"
          class="p-filterable-dropdown"
-         :class="[ {'multi-selectable' : props.multiSelectable} ]"
+         :class="{ disabled, opened: proxyVisibleMenu, invalid }"
     >
-        <p-search ref="targetRef"
-                  :value="state.proxyValue"
-                  :placeholder="state.placeholderValue ? state.placeholderValue : $t('COMPONENT.FILTERABLE_DROPDOWN.SINGLE_PLACEHOLDER')"
-                  disable-icon
-                  :is-focused.sync="state.proxyIsFocused"
-                  :invalid="invalid"
-                  :disabled="disabled"
-                  :readonly="readonly"
-                  @delete="onDeleteSearchText"
-                  @click.native.stop="handleClick"
-                  @search="onSearch"
-                  @input="onInput"
-                  @keyup.native="handleSearchKeyup"
-                  @focus="handleSearchFocus"
+        <div ref="targetRef"
+             class="dropdown-button"
+             :tabindex="disabled || readonly ? -1 : 0"
+             @keyup.down="focusMenu"
+             @keyup.esc.capture.stop="hideMenu"
+             @keyup.enter.capture.stop="toggleMenu"
+             @click="toggleMenu"
         >
-            <div v-if="state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.radioButton &&
-                     state.proxySelected.length &&
-                     !state.proxyVisibleMenu &&
-                     !state.proxyIsFocused"
-                 class="selected-radio-label"
-            >
-                <span><slot name="selected-radio-label"
-                            :selected="state.proxySelected[0]"
-                >{{ state.proxySelected[0].label || state.proxySelected[0].name }}</slot></span>
-                <p-i class="delete-icon"
-                     name="ic_delete"
-                     height="1rem"
-                     width="1rem"
-                     @click="onDeleteTag(state.proxySelected[0], 0)"
-                />
-            </div>
-            <slot name="selected-extra"
-                  v-bind="{items: state.proxySelected}"
-            />
-            <template v-if="multiSelectable && state.proxySelected.length"
-                      #left
-            >
-                <p-tag v-for="(selectedItem, index) in state.proxySelected"
-                       :key="`tag-box-${index}`"
-                       :deletable="!disabled"
-                       @delete="onDeleteTag(selectedItem, index)"
+            <div class="selection-display-wrapper">
+                <span v-if="displayValueOnDropdownButton"
+                      class="selected-item"
                 >
-                    {{ selectedItem.label || selectedItem.name }}
-                </p-tag>
-                <p-i v-if="!disableDeleteAll"
-                     class="delete-icon"
-                     name="ic_delete"
-                     height="1rem"
-                     width="1rem"
-                     @click="onDeleteAllTags"
-                />
-            </template>
-            <template v-if="state.filterableDropdownType !== FILTERABLE_DROPDOWN_TYPE.default || !state.proxySelected.length || props.visibleMenu"
-                      #right
-            >
-                <p-i :name="state.proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
-                     color="inherit"
-                     class="dropdown-button"
-                     :class="disabled"
-                     @click.stop="handleClickDropdownButton"
-                />
-            </template>
-            <template v-for="(_, slot) of state.searchSlots"
-                      #[slot]="scope"
-            >
-                <slot :name="`search-${slot}`"
-                      v-bind="{...scope}"
-                />
-            </template>
-        </p-search>
-        <p-context-menu v-show="state.proxyVisibleMenu"
-                        ref="menuRef"
-                        :menu="state.bindingMenu"
-                        :loading="loading"
-                        :readonly="readonly"
-                        :strict-select-mode="strictSelectMode"
-                        :selected.sync="state.proxySelected"
-                        :multi-selectable="multiSelectable"
-                        :show-select-header="multiSelectable"
-                        :show-select-marker="state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.radioButton"
-                        :style="{...contextMenuStyle, maxWidth: contextMenuStyle.minWidth, width: contextMenuStyle.minWidth}"
-                        :class="state.filterableDropdownType"
-                        @select="handleSelectMenuItem"
-                        @keyup:up:end="focusSearch"
-                        @keyup:esc="focusSearch"
-                        @focus="onFocusMenuItem"
-                        @click-done="forceHideMenu"
-        >
-            <template #item--format="{item}">
-                <span class="p-filterable-dropdown__item-label">
-                    <span v-for="(text, i) in item.label.split(state.searchRegex)"
-                          :key="`item-label--${text}-${i}`"
-                          :class="{ 'selected': state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default && item.name === state.selectedNames[0] }"
-                    >
-                        <span v-if="i !== 0"
-                              class="font-bold"
-                        >{{ getMatchText(item.label) }}</span><span>{{ text }}</span>
-                    </span>
+                    {{ displayValueOnDropdownButton }}
+                    <p-badge v-if="displayBadgeValueOnDropdownButton">
+                        {{ displayBadgeValueOnDropdownButton }}
+                    </p-badge>
                 </span>
-            </template>
-            <template v-for="(_, slot) of state.menuSlots"
+                <div v-else-if="showTagsOnDropdownButton"
+                     class="tags-wrapper"
+                >
+                    <p-tag v-for="(item, idx) in proxySelected"
+                           :key="item.name"
+                           class="selected-tag"
+                           @delete="handleTagDelete(item, idx)"
+                    >
+                        {{ item.label || item.name }}
+                    </p-tag>
+                </div>
+                <span v-if="showDeleteAllButton"
+                      class="delete-all-button"
+                      @click.stop="handleClickDeleteAll"
+                >
+                    <p-i name="ic_delete"
+                         width="1rem"
+                         height="1rem"
+                         color="inherit"
+                    />
+                </span>
+            </div>
+            <span class="arrow-button"
+                  @click.stop="toggleMenu"
+            >
+                <p-i :name="proxyVisibleMenu ? 'ic_arrow_top' : 'ic_arrow_bottom'"
+                     width="1.5rem"
+                     height="1.5rem"
+                     color="inherit"
+                />
+            </span>
+        </div>
+        <p-context-menu v-show="proxyVisibleMenu"
+                        ref="menuRef"
+                        class="dropdown-context-menu"
+                        :search-text="proxySearchText"
+                        searchable
+                        :menu="displayMenuItems"
+                        :loading="props.loading || handlerLoading"
+                        :readonly="props.readonly"
+                        :selected="proxySelected"
+                        :multi-selectable="props.multiSelectable"
+                        :show-select-header="props.showSelectHeader"
+                        :show-select-marker="props.showSelectMarker"
+                        :style="fixedMenuStyle"
+                        :class="{ default: !props.showSelectMarker }"
+                        @select="handleSelectMenuItem"
+                        @click-done="hideMenu"
+                        @click-show-more="handleClickShowMore"
+                        @keyup:up:end="focusDropdownButton"
+                        @keyup:down:end="focusMenu"
+                        @keyup:esc="hideMenu"
+                        @update:selected="handleUpdateSelected"
+                        @update:search-text="handleUpdateSearchText"
+        >
+            <template v-for="(_, slot) of menuSlots"
                       #[slot]="scope"
             >
                 <slot :name="`menu-${slot}`"
@@ -116,439 +88,307 @@
 
 <script setup lang="ts">
 import {
-    computed, onMounted, onUnmounted, reactive, watch, nextTick, toRef, useSlots, ref,
+    computed, watch, useSlots, ref, toRef,
 } from 'vue';
 
 // CAUTION: this vOnClickOutside is using !! Please do not remove.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { vOnClickOutside } from '@vueuse/components';
+import { useFocus } from '@vueuse/core';
 import { reduce } from 'lodash';
 
+import PBadge from '@/data-display/badges/PBadge.vue';
 import PTag from '@/data-display/tags/PTag.vue';
 import PI from '@/foundation/icons/PI.vue';
-import { useProxyValue } from '@/hooks';
-import { useContextMenuFixedStyle } from '@/hooks/context-menu-fixed-style';
+import { useContextMenuController, useProxyValue } from '@/hooks';
+import { useIgnoreWindowArrowKeydownEvents } from '@/hooks/ignore-window-arrow-keydown-events';
 import PContextMenu from '@/inputs/context-menu/PContextMenu.vue';
-import type { MenuItem } from '@/inputs/context-menu/type';
+import {
+    useFilterableDropdownButtonDisplay,
+} from '@/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-button-display';
+import {
+    useFilterableDropdownMenuFiltering,
+} from '@/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-menu-filtering';
 import type {
     FilterableDropdownMenuItem,
-    AutocompleteHandler,
+    AutocompleteHandler, FilterableDropdownAppearanceType,
 } from '@/inputs/dropdown/filterable-dropdown/type';
-import {
-    FILTERABLE_DROPDOWN_TYPE,
-} from '@/inputs/dropdown/filterable-dropdown/type';
-import PSearch from '@/inputs/search/search/PSearch.vue';
+import { FILTERABLE_DROPDOWN_APPEARANCE_TYPES } from '@/inputs/dropdown/filterable-dropdown/type';
 
+/* props */
 interface FilterableDropdownProps {
-    /* search props */
-    value?: string;
-    placeholder?: string;
-    isFocused?: boolean;
-    invalid?: boolean;
-    disabled?: boolean;
-    readonly?: boolean;
     /* context menu props */
-    menu?: MenuItem[];
+    menu?: FilterableDropdownMenuItem[];
     loading?: boolean;
     selected?: FilterableDropdownMenuItem[];
     multiSelectable?: boolean;
+    searchText?: string;
+    readonly?: boolean;
+    showSelectHeader?: boolean;
+    showSelectMarker?: boolean;
+    /* others */
     visibleMenu?: boolean;
     useFixedMenuStyle?: boolean;
-    /* extra props */
-    type?: FILTERABLE_DROPDOWN_TYPE;
+    placeholder?: string;
+    invalid?: boolean;
+    disabled?: boolean;
+    // eslint-disable-next-line vue/require-default-prop
     handler?: AutocompleteHandler;
     disableHandler?: boolean;
-    exactMode?: boolean;
-    strictSelectMode?: boolean;
-    disableDeleteAll?: boolean;
+    appearanceType?: FilterableDropdownAppearanceType;
+    // eslint-disable-next-line vue/require-default-prop
+    pageSize?: number;
 }
 const props = withDefaults(defineProps<FilterableDropdownProps>(), {
-    value: '',
-    isFocused: false,
-    invalid: false,
-    disabled: false,
-    readonly: false,
     menu: () => [],
     loading: false,
     selected: () => [],
-    multiSelectable: false,
+    searchText: '',
     visibleMenu: undefined,
-    useFixedMenuStyle: false,
-    disableHandler: false,
-    exactMode: true,
-    strictSelectMode: false,
-    disableDeleteAll: false,
-});
-const emit = defineEmits<{(e: string, ...args: any[]): void; }>();
-const slots = useSlots();
-
-const menuRef = ref<any|null>(null);
-const state = reactive({
-    proxyVisibleMenu: useProxyValue<boolean>('visibleMenu', props, emit),
-    filterableDropdownType: computed<FILTERABLE_DROPDOWN_TYPE | undefined>(() => {
-        if (props.type) return props.type;
-        if (!props.multiSelectable) return FILTERABLE_DROPDOWN_TYPE.default;
-        return undefined;
-    }),
-    proxyValue: useProxyValue('value', props, emit),
-    proxyIsFocused: useProxyValue('isFocused', props, emit),
-    proxySelected: useProxyValue('selected', props, emit),
-    placeholderValue: undefined as string|undefined,
-    filteredMenu: [] as FilterableDropdownMenuItem[],
-    bindingMenu: computed<FilterableDropdownMenuItem[]>(() => (props.disableHandler ? props.menu : state.filteredMenu)),
-    searchableItems: computed<FilterableDropdownMenuItem[]>(() => props.menu.filter((d) => d.type === undefined || d.type === 'item')),
-    searchRegex: computed(() => new RegExp(state.proxyValue || '', 'i')),
-    selectedNames: computed(() => state.proxySelected.map((item) => item.name)),
-    //
-    menuSlots: computed(() => reduce(slots, (res, d, name) => {
-        if (name.startsWith('menu-')) res[`${name.substring(5)}`] = d;
-        return res;
-    }, {})),
-    searchSlots: computed(() => reduce(slots, (res, d, name) => {
-        if (name.startsWith('search-')) res[`${name.substring(7)}`] = d;
-        return res;
-    }, {})),
+    placeholder: undefined,
+    appearanceType: FILTERABLE_DROPDOWN_APPEARANCE_TYPES[0],
 });
 
-const {
-    targetRef, contextMenuStyle,
-} = useContextMenuFixedStyle({
-    useFixedMenuStyle: computed(() => props.useFixedMenuStyle),
-    visibleMenu: toRef(state, 'proxyVisibleMenu'),
-});
+/* event emits */
+const emit = defineEmits<{(e: 'update:visible-menu', visibleMenu: boolean): void;
+    (e: 'update:search-text', searchText: string): void;
+    (e: 'update:selected', selected: FilterableDropdownMenuItem[]): void;
+    (e: 'select', item: FilterableDropdownMenuItem): void;
+    (e: 'delete-tag', item: FilterableDropdownMenuItem, index: number): void;
+    (e: 'click-show-more'): void;
+}>();
 
-const defaultHandler = (inputText: string, list: FilterableDropdownMenuItem[]) => {
-    let results: FilterableDropdownMenuItem[] = [...list];
-    const trimmed = inputText.trim();
-    if (trimmed) {
-        const regex = new RegExp(inputText, 'i');
-        results = results.filter((d) => regex.test(d.label as string));
-    }
-    return { results };
-};
-
-const filterMenu = async (val: string) => {
-    if (props.disableHandler) return;
-
-    if (props.handler) {
-        let res = props.handler(val, state.searchableItems);
-        if (res instanceof Promise) res = await res;
-        state.filteredMenu = res.results;
-    } else {
-        const results = defaultHandler(val, state.searchableItems).results;
-
-        const filtered = props.menu.filter((item) => {
-            if (item.type && item.type !== 'item') return true;
-            return !!results.find((d) => d.label === item.label);
-        });
-        if (filtered[filtered.length - 1]?.type === 'divider') filtered.pop();
-        state.filteredMenu = filtered;
+/* menu visibility */
+const proxyVisibleMenu = useProxyValue<boolean>('visibleMenu', props, emit);
+const hideMenu = () => {
+    if (proxyVisibleMenu.value) {
+        proxyVisibleMenu.value = false;
+        proxySearchText.value = '';
     }
 };
-
-const getMatchText = (text: string): string => {
-    const res = state.searchRegex.exec(text);
-    if (res) return res[0];
-    return '';
-};
-
-
-/* event util */
-const focusSearch = () => {
-    if (state.proxyIsFocused) return;
-    state.proxyIsFocused = true;
-};
-
-const hideMenu = (mode?: string) => {
-    if (!state.proxyVisibleMenu) return;
-    // placeholder
-    const isRadioItemSelected = state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.radioButton && (mode === 'click' || state.proxySelected.length);
-    if (isRadioItemSelected) {
-        state.placeholderValue = '';
-    } else if (props.multiSelectable && state.proxySelected.length) {
-        state.placeholderValue = ' ';
-    } else {
-        state.placeholderValue = props.placeholder;
-    }
-
-    // value
-    const isDefaultItemSelected = state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default && mode !== 'click';
-    if (isDefaultItemSelected) {
-        const item = state.proxySelected[0];
-        if (item) state.proxyValue = item.label ?? item.name ?? '';
-        else state.proxyValue = '';
-    }
-    if (state.filterableDropdownType !== FILTERABLE_DROPDOWN_TYPE.default) {
-        state.proxyValue = '';
-    }
-
-    state.proxyVisibleMenu = false;
-    emit('hide-menu');
-};
-
 const showMenu = () => {
-    if (state.proxyVisibleMenu) return;
-
-    if (
-        state.proxySelected.length && (
-            state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default
-                    || state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.radioButton
-        )
-    ) {
-        // If there is an existing selected item, the value will be placeholder & filter will be initialized
-        const selectedItem = state.proxySelected[0] as FilterableDropdownMenuItem;
-        state.placeholderValue = selectedItem.label ?? selectedItem.name ?? '';
-        state.proxyValue = '';
-        filterMenu('');
-    } else {
-        filterMenu(state.proxyValue);
-    }
-
-    state.proxyVisibleMenu = true;
-    emit('show-menu');
+    if (!proxyVisibleMenu.value && !props.disabled) proxyVisibleMenu.value = true;
 };
-
-const focusMenu = () => {
-    if (state.bindingMenu.length === 0) return;
-    if (menuRef.value) menuRef.value.focus();
-};
-
-const allFocusOut = () => {
-    if (!state.proxyIsFocused) return;
-    state.proxyIsFocused = false;
-    hideMenu();
-};
-
-
-/* event */
-const onFocusMenuItem = (index: string) => {
-    emit('focus-menu', index);
-};
-
-const onFocusSearchInput = () => {
-    showMenu();
-};
-
-const onDeleteTag = (item: FilterableDropdownMenuItem, index: number) => {
-    state.proxySelected.splice(index, 1);
-    state.proxySelected = [...state.proxySelected];
-    emit('delete-tag', item, index);
-};
-
-const onDeleteAllTags = () => {
-    state.proxySelected = [];
-    emit('delete-all-tags');
-};
-
-const onDeleteSearchText = (...args) => {
-    if (state.proxyValue) {
-        state.proxyValue = '';
-    }
-
-    if (state.proxySelected.length === 0) return;
-
-    if (state.filterableDropdownType !== FILTERABLE_DROPDOWN_TYPE.default) return;
-
-    const item = state.proxySelected[0];
-    state.proxySelected.splice(0, 1);
-    emit('delete-tag', item, 0);
-    emit('delete', ...args);
-    emit('search', '');
-    focusSearch();
-};
-
-const onInput = (val: string, e) => {
-    if (!state.proxyVisibleMenu) showMenu();
-
-    state.proxyValue = val;
-
-    emit('input', val, e);
-
-    filterMenu(val);
-};
-
-const handleSelectMenuItem = (item: FilterableDropdownMenuItem) => {
-    if ([FILTERABLE_DROPDOWN_TYPE.default, FILTERABLE_DROPDOWN_TYPE.radioButton].includes(state.filterableDropdownType)) {
-        hideMenu('click');
-    }
-    if (state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default) {
-        state.proxyValue = item.label ?? item.name ?? '';
-    }
-    if (props.multiSelectable) state.proxyIsFocused = true;
-
-    emit('select-menu', item);
-};
-
-const onSearch = (val?: string) => {
-    const trimmed = val?.trim() ?? '';
-    const menuItem = state.filteredMenu.find((d) => trimmed.toLowerCase() === d.label?.toLowerCase());
-    if (menuItem) {
-        emit('select-menu', menuItem);
-        state.proxyValue = menuItem.label ?? menuItem.name ?? '';
-        if (state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default) {
-            state.proxySelected = [menuItem];
-        } else if (!state.selectedNames.includes(menuItem.name)) {
-            state.proxySelected.push(menuItem);
-        }
-    } else if (state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default) {
-        if (!state.proxySelected.length) state.proxyValue = '';
-    }
-
-    if (!menuItem && props.exactMode) {
-        state.proxyValue = '';
-        emit('search', '');
-    } else {
-        emit('search', trimmed);
-    }
-
-    nextTick(() => {
-        allFocusOut();
-    });
-};
-
-
-const handleClickDropdownButton = () => {
-    if (props.disabled) return;
-    if (state.proxyVisibleMenu) hideMenu();
+const toggleMenu = () => {
+    if (proxyVisibleMenu.value) hideMenu();
     else showMenu();
 };
 
-const handleClick = (e) => {
-    if (props.disabled) return;
-    state.proxyIsFocused = true;
-    showMenu();
-    emit('click', e);
-};
-
-const handleSearchKeyup = (e) => {
-    if (e.key === 'ArrowDown' || e.key === 'Down') focusMenu();
-    else if (e.key === 'Escape' || e.key === 'Esc') allFocusOut();
-    emit('keyup', e);
-};
-const handleSearchFocus = (e) => {
-    onFocusSearchInput();
-    emit('focus', e);
-};
-
-const onWindowKeydown = (e: KeyboardEvent) => {
-    if (state.proxyVisibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.key)) {
-        e.preventDefault();
-    }
-};
-const forceHideMenu = () => {
-    hideMenu();
-};
-
-onMounted(() => {
-    window.addEventListener('keydown', onWindowKeydown, false);
-});
-onUnmounted(() => {
-    window.removeEventListener('keydown', onWindowKeydown, false);
+/* context menu style */
+const menuRef = ref<any|null>(null);
+const targetRef = ref<HTMLElement|null>(null);
+const {
+    fixedMenuStyle,
+} = useContextMenuController({
+    useFixedStyle: computed(() => props.useFixedMenuStyle),
+    targetRef,
+    contextMenuRef: menuRef,
+    visibleMenu: proxyVisibleMenu,
 });
 
-watch(() => props.menu, (menu) => {
-    state.filteredMenu = menu;
-    filterMenu(state.proxyValue);
+/* focusing */
+const { focused: focusedOnDropdownButton } = useFocus(targetRef);
+const focusDropdownButton = () => {
+    if (focusedOnDropdownButton.value) return;
+    focusedOnDropdownButton.value = true;
+};
+const focusMenu = () => {
+    if (!proxyVisibleMenu.value) showMenu();
+    if (menuRef.value) menuRef.value.focus();
+};
+
+/* menu filtering */
+const proxySearchText = useProxyValue('searchText', props, emit);
+const {
+    handlerLoading,
+    displayMenuItems,
+    resetMenu,
+    filterMenu,
+    attachMoreItems,
+} = useFilterableDropdownMenuFiltering({
+    searchText: proxySearchText,
+    disableHandler: toRef(props, 'disableHandler'),
+    handler: toRef(props, 'handler'),
+    menu: toRef(props, 'menu'),
+    pageSize: toRef(props, 'pageSize'),
 });
-
-watch(() => state.proxySelected, (proxySelected) => {
-    if (!proxySelected.length) {
-        state.placeholderValue = props.placeholder;
-        if (state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default) state.proxyValue = '';
-        return;
-    }
-
-    if (state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.default) {
-        const item = state.proxySelected[0];
-        if (item) state.proxyValue = item.label ?? item.name ?? '';
-        else state.proxyValue = '';
-    } else if (state.filterableDropdownType === FILTERABLE_DROPDOWN_TYPE.radioButton && state.placeholderValue !== '') {
-        state.placeholderValue = '';
+const handleClickShowMore = async () => {
+    await attachMoreItems();
+    emit('click-show-more');
+};
+const handleUpdateSearchText = (searchText: string) => {
+    proxySearchText.value = searchText;
+    filterMenu();
+};
+watch([() => props.menu, proxyVisibleMenu], ([, visibleMenu]) => {
+    if (visibleMenu) {
+        resetMenu();
+        filterMenu();
     }
 }, { immediate: true });
 
+
+/* selection */
+const proxySelected = useProxyValue<FilterableDropdownMenuItem[]>('selected', props, emit);
+const handleSelectMenuItem = (item: FilterableDropdownMenuItem) => {
+    if (!props.multiSelectable) hideMenu();
+    emit('select', item);
+};
+const handleUpdateSelected = (selectedItems: FilterableDropdownMenuItem[]) => {
+    if (proxySelected.value !== selectedItems && !(proxySelected.value.length === 0 && selectedItems.length === 0)) {
+        proxySelected.value = selectedItems;
+    }
+};
+
+/* deletion */
+const showDeleteAllButton = computed(() => {
+    if (props.disabled) return false;
+    if (props.readonly) return false;
+    return !!proxySelected.value.length;
+});
+const handleClickDeleteAll = () => {
+    if (proxySelected.value.length) {
+        proxySelected.value = [];
+    }
+};
+const handleTagDelete = (item: FilterableDropdownMenuItem, idx: number) => {
+    const selectedClone = [...proxySelected.value];
+    selectedClone.splice(idx, 1);
+    proxySelected.value = selectedClone;
+    emit('delete-tag', item, idx);
+};
+
+/* disabled */
 watch(() => props.disabled, (disabled) => {
-    if (disabled === true) forceHideMenu();
+    if (disabled) hideMenu();
 });
 
+/* slots */
+const slots = useSlots();
+const menuSlots = computed(() => reduce(slots, (res, d, name) => {
+    if (name.startsWith('menu-')) res[`${name.substring(5)}`] = d;
+    return res;
+}, {}));
+
+/* dropdown button display */
+const {
+    displayValueOnDropdownButton,
+    showTagsOnDropdownButton,
+    displayBadgeValueOnDropdownButton,
+} = useFilterableDropdownButtonDisplay({
+    multiSelectable: toRef(props, 'multiSelectable'),
+    selected: proxySelected,
+    appearanceType: toRef(props, 'appearanceType'),
+    placeholder: toRef(props, 'placeholder'),
+});
+
+/* ignore window arrow keydown event */
+useIgnoreWindowArrowKeydownEvents({ predicate: proxyVisibleMenu });
 </script>
 
 <style lang="postcss">
 .p-filterable-dropdown {
-    @apply w-full relative;
-    .p-search {
-        .input-container {
-            @apply text-sm font-normal;
-            &.disabled {
-                @apply text-gray-300;
-                .dropdown-button {
-                    cursor: default;
+    @apply w-full;
+    position: relative;
+    > .dropdown-button {
+        @apply bg-white border rounded-md border-gray-300;
+        display: flex;
+        width: 100%;
+        min-height: 2rem;
+        cursor: pointer;
+        > .selection-display-wrapper {
+            flex-grow: 1;
+            display: flex;
+            width: 100%;
+            > .selected-item {
+                @apply text-label-md text-gray-900;
+                flex-grow: 1;
+                padding: 0.375rem 0.5rem;
+            }
+            > .tags-wrapper {
+                flex-grow: 1;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.5rem;
+                padding: 0.375rem 0.5rem;
+                > .selected-tag {
+                    margin: 0;
                 }
             }
-            &.focused:not(.disabled) {
-                .dropdown-button {
-                    @apply text-secondary;
-                }
+            > .delete-all-button {
+                @apply text-gray-400;
+                flex-shrink: 0;
+                display: inline-flex;
+                align-items: center;
+                cursor: pointer;
+                height: 2rem;
+                width: 1rem;
             }
         }
+        .arrow-button {
+            @apply text-gray-900;
+            flex-shrink: 0;
+            display: inline-flex;
+            align-items: center;
+            cursor: pointer;
+            height: 2rem;
+            width: 2rem;
+        }
     }
-    .selected-radio-label {
-        @apply w-full flex justify-between items-center;
-        padding-top: 0.375rem;
-        padding-bottom: 0.375rem;
-        line-height: 1.125rem;
-    }
-    .delete-icon {
-        @apply min-w-4;
-    }
-    .dropdown-button {
-        cursor: pointer;
-        flex-shrink: 0;
-    }
-    .p-context-menu {
-        @apply font-normal;
+    > .dropdown-context-menu {
         position: absolute;
-        margin-top: -1px;
         z-index: 1000;
         min-width: 100%;
         width: 100%;
+    }
 
-        &.default {
-            .context-item {
-                &.selected {
-                    @apply bg-blue-200;
+    &.disabled {
+        > .dropdown-button {
+            @apply bg-gray-100 border-gray-300;
+            cursor: not-allowed;
+            > .selection-display-wrapper {
+                > .selected-item {
+                    @apply text-gray-300;
                 }
-                &:not(.disabled):not(.empty) {
-                    &:hover, &:focus {
-                        @apply bg-blue-100;
-                    }
+                > .delete-all-button {
+                    cursor: not-allowed;
                 }
             }
-        }
-
-        .p-filterable-dropdown__item-label {
-            flex-grow: 1;
+            > .arrow-button {
+                @apply text-gray-300;
+                cursor: not-allowed;
+            }
         }
     }
 
-    &.multi-selectable {
-        .p-search {
-            .input-container {
-                @apply relative flex-wrap row-gap-1;
-                padding-right: 3rem;
-                padding-top: 0.25rem;
-                padding-bottom: 0.25rem;
-
-                .dropdown-button {
-                    @apply absolute;
-                    top: 0.1875rem;
-                    right: 0.5rem;
+    &.opened {
+        > .dropdown-button {
+            @apply border-secondary;
+            > .selection-display-wrapper {
+                > .selected-item {
+                    @apply text-secondary;
                 }
-                > .delete-icon {
-                    @apply absolute cursor-pointer;
-                    right: 2rem;
-                    top: 0.4375rem;
-                    height: 100%;
+            }
+            > .arrow-button {
+                @apply text-secondary;
+            }
+        }
+    }
+
+    &.invalid {
+        > .dropdown-button {
+            @apply border-alert;
+        }
+    }
+
+    @media (hover: hover) {
+        &:not(.disabled):hover {
+            > .dropdown-button .arrow-button {
+                @apply text-secondary;
+            }
+            &:not(.invalid) {
+                > .dropdown-button {
+                    @apply border-secondary;
                 }
             }
         }

--- a/src/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-button-display.ts
+++ b/src/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-button-display.ts
@@ -1,0 +1,50 @@
+import type { Ref } from 'vue';
+import { computed } from 'vue';
+
+import type {
+    FilterableDropdownAppearanceType,
+    FilterableDropdownMenuItem,
+} from '@/inputs/dropdown/filterable-dropdown/type';
+import { i18n } from '@/translations';
+
+interface UseDropdownButtonDisplay {
+    multiSelectable: Ref<boolean|undefined>;
+    selected: Ref<FilterableDropdownMenuItem[]>;
+    appearanceType: Ref<FilterableDropdownAppearanceType>;
+    placeholder: Ref<string|undefined>;
+}
+export const useFilterableDropdownButtonDisplay = ({
+    multiSelectable, selected, appearanceType, placeholder,
+}: UseDropdownButtonDisplay) => {
+    const displayValueOnDropdownButton = computed(() => {
+        if (multiSelectable.value) {
+            if (appearanceType.value === 'badge') {
+                if (selected.value[0]) return selected.value[0].label || selected.value[0].name;
+                return placeholder.value ?? i18n.t('COMPONENT.FILTERABLE_DROPDOWN.PLACEHOLDER');
+            }
+            if (appearanceType.value === 'stack') {
+                if (selected.value.length > 0) return '';
+                return placeholder.value ?? i18n.t('COMPONENT.FILTERABLE_DROPDOWN.PLACEHOLDER');
+            }
+            // basic case
+            if (selected.value.length) return selected.value.map((d) => d.label ?? d.name).join(', ');
+            return placeholder.value ?? i18n.t('COMPONENT.FILTERABLE_DROPDOWN.PLACEHOLDER');
+        }
+        // single select case
+        if (selected.value[0]) return selected.value[0].label || selected.value[0].name;
+        return placeholder.value ?? i18n.t('COMPONENT.FILTERABLE_DROPDOWN.PLACEHOLDER');
+    });
+    const showTagsOnDropdownButton = computed(() => multiSelectable.value && appearanceType.value === 'stack');
+    const displayBadgeValueOnDropdownButton = computed(() => {
+        if (multiSelectable.value && appearanceType.value === 'badge') {
+            if (selected.value.length > 1) return `+${selected.value.length - 1}`;
+            return undefined;
+        }
+        return undefined;
+    });
+    return {
+        displayValueOnDropdownButton,
+        showTagsOnDropdownButton,
+        displayBadgeValueOnDropdownButton,
+    };
+};

--- a/src/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-menu-filtering.ts
+++ b/src/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-menu-filtering.ts
@@ -1,0 +1,126 @@
+import type { Ref } from 'vue';
+import { computed, ref } from 'vue';
+
+import type { AutocompleteHandler, FilterableDropdownMenuItem } from '@/inputs/dropdown/filterable-dropdown/type';
+
+interface UseFilterableDropdownMenuFilteringOptions {
+    searchText: Ref<string>;
+    disableHandler: Ref<boolean|undefined>;
+    handler: Ref<AutocompleteHandler|undefined>;
+    menu: Ref<FilterableDropdownMenuItem[]>;
+    pageSize: Ref<number|undefined>
+}
+export const useFilterableDropdownMenuFiltering = ({
+    searchText, disableHandler, handler, menu, pageSize,
+}: UseFilterableDropdownMenuFilteringOptions) => {
+    const handlerLoading = ref<boolean>(false);
+
+    // default handler case only
+    const filteredItems = ref<FilterableDropdownMenuItem[]>([]);
+    const menuItemsByDefaultHandler = computed<FilterableDropdownMenuItem[]>(() => {
+        if (!pageSize.value) return filteredItems.value;
+
+        if (filteredItems.value.length > pageLimit.value) {
+            const sliced = filteredItems.value.slice(0, pageLimit.value);
+            return [
+                ...sliced,
+                { type: 'showMore', name: 'filterableDropdownShowMore' },
+            ] as FilterableDropdownMenuItem[];
+        }
+        return filteredItems.value;
+    });
+
+    // custom handler case only
+    const accumulatedItemsByCustomHandler = ref<FilterableDropdownMenuItem[]>([]);
+    const hasNextItemsByCustomHandler = ref<boolean>(false);
+    const menuItemsByCustomHandler = computed<FilterableDropdownMenuItem[]>(() => {
+        if (hasNextItemsByCustomHandler.value) {
+            return [
+                ...accumulatedItemsByCustomHandler.value,
+                { type: 'showMore', name: 'filterableDropdownShowMore' },
+            ] as FilterableDropdownMenuItem[];
+        }
+        return accumulatedItemsByCustomHandler.value;
+    });
+
+    // pagination
+    const pageNumber = ref<number>(0);
+    const pageStart = computed(() => (pageNumber.value) * (pageSize.value ?? 0) + 1);
+    const pageLimit = computed(() => (pageNumber.value + 1) * (pageSize.value ?? 0));
+
+    // actual display menu items
+    const displayMenuItems = computed<FilterableDropdownMenuItem[]>(() => {
+        if (disableHandler.value) return menu.value;
+        // custom handler case
+        if (handler.value) {
+            return menuItemsByCustomHandler.value;
+        }
+        // default handler case
+        return menuItemsByDefaultHandler.value;
+    });
+
+    const resetMenu = () => {
+        if (disableHandler.value) return;
+        if (handler.value) {
+            accumulatedItemsByCustomHandler.value = [];
+            hasNextItemsByCustomHandler.value = false;
+        } else filteredItems.value = [];
+    };
+    const resetPagination = () => {
+        pageNumber.value = 0;
+    };
+
+    const defaultHandler = () => {
+        let results: FilterableDropdownMenuItem[];
+        const trimmed = searchText.value.trim();
+        if (trimmed) {
+            const regex = new RegExp(trimmed, 'i');
+            results = menu.value.filter((d) => {
+                if (d.type === undefined || d.type === 'item') return regex.test(d.label as string);
+                return true;
+            });
+        } else {
+            results = menu.value;
+        }
+        filteredItems.value = results;
+    };
+    const customHandler = async (val: string, start: number, limit: number): Promise<{ results: FilterableDropdownMenuItem[], more: boolean }> => {
+        if (!handler.value) return { results: [], more: false };
+        let res = handler.value(val, start, limit);
+        if (res instanceof Promise) res = await res;
+        return { results: res.results, more: !!res.more };
+    };
+
+    const filterMenu = async () => {
+        if (disableHandler.value) return;
+        handlerLoading.value = true;
+        resetPagination();
+        if (handler.value) {
+            const { results, more } = await customHandler(searchText.value, pageStart.value, pageLimit.value);
+            hasNextItemsByCustomHandler.value = more;
+            accumulatedItemsByCustomHandler.value = results;
+        } else {
+            defaultHandler();
+        }
+        handlerLoading.value = false;
+    };
+
+    const attachMoreItems = async () => {
+        pageNumber.value += 1;
+        if (!disableHandler.value && handler.value) {
+            handlerLoading.value = true;
+            const { results, more } = await customHandler(searchText.value, pageStart.value, pageLimit.value);
+            hasNextItemsByCustomHandler.value = more;
+            accumulatedItemsByCustomHandler.value = accumulatedItemsByCustomHandler.value.concat(results);
+            handlerLoading.value = false;
+        }
+    };
+
+    return {
+        handlerLoading,
+        displayMenuItems,
+        resetMenu,
+        filterMenu,
+        attachMoreItems,
+    };
+};

--- a/src/inputs/dropdown/filterable-dropdown/mock.ts
+++ b/src/inputs/dropdown/filterable-dropdown/mock.ts
@@ -1,15 +1,23 @@
 import { faker } from '@faker-js/faker';
 import { range } from 'lodash';
 
-const getMenuItem = () => ({
-    name: faker.datatype.uuid(),
-    label: `${faker.random.word()}`, // (${faker.random.word()})`,
-    type: 'item',
-    // disabled: faker.datatype.boolean(),
-});
+import type { FilterableDropdownMenuItem } from '@/inputs/dropdown/filterable-dropdown/type';
 
-export const getSearchDropdownMenu = (min = 10, max = 30) => range(faker.datatype.number({ min, max })).map(() => getMenuItem());
-export const getSearchDropdownMenuWithMultiTypes = () => range(30).map((i) => {
+const getMenuItem = (word?: string): FilterableDropdownMenuItem => {
+    let label = faker.random.word();
+    if (word) {
+        label = label.slice(0, label.length / 2) + word + label.slice(label.length / 2);
+    }
+    return {
+        name: faker.datatype.uuid(),
+        label,
+        type: 'item',
+        // disabled: faker.datatype.boolean(),
+    };
+};
+
+export const getFilterableDropdownMenu = (min = 10, max = 30, word?: string): FilterableDropdownMenuItem[] => range(faker.datatype.number({ min, max })).map(() => getMenuItem(word));
+export const getFilterableDropdownMenuWithMultiTypes = (): FilterableDropdownMenuItem[] => range(30).map((i) => {
     const result = getMenuItem();
 
     if ([0, 10, 20].includes(i)) {
@@ -20,3 +28,4 @@ export const getSearchDropdownMenuWithMultiTypes = () => range(30).map((i) => {
 
     return result;
 });
+

--- a/src/inputs/dropdown/filterable-dropdown/story-helper.ts
+++ b/src/inputs/dropdown/filterable-dropdown/story-helper.ts
@@ -1,29 +1,99 @@
 import type { ArgTypes } from '@storybook/addons';
 
 import { getContextMenuArgTypes } from '@/inputs/context-menu/story-helper';
-import { FILTERABLE_DROPDOWN_TYPE } from '@/inputs/dropdown/filterable-dropdown/type';
-import { getSearchArgTypes } from '@/inputs/search/search/story-helper';
+import { FILTERABLE_DROPDOWN_APPEARANCE_TYPES } from '@/inputs/dropdown/filterable-dropdown/type';
 
 
 const extraArgTypes: ArgTypes = {
     /* props */
-    type: {
-        name: 'type',
+    visibleMenu: {
+        name: 'visibleMenu',
+        type: { name: 'boolean' },
+        description: 'Use this prop when you want to control menu visibility manually. this is `sync` prop with event `update:visible-menu`.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    useFixedMenuStyle: {
+        name: 'useFixedMenuStyle',
+        type: { name: 'boolean' },
+        description: 'Whether to use position fixed style on menu or not. ',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    placeholder: {
+        name: 'placeholder',
         type: { name: 'string' },
-        description: 'Type of single selection. Do not work in multi select mode. There are 2 types: `default` and `radioButton`.',
-        defaultValue: FILTERABLE_DROPDOWN_TYPE.default,
+        description: 'Search input placeholder.',
+        defaultValue: undefined,
         table: {
             type: {
                 summary: 'string',
             },
             category: 'props',
             defaultValue: {
-                summary: 'default',
+                summary: 'undefined',
             },
         },
         control: {
-            type: 'select',
-            options: Object.values(FILTERABLE_DROPDOWN_TYPE),
+            type: 'text',
+        },
+    },
+    invalid: {
+        name: 'invalid',
+        type: { name: 'boolean' },
+        description: 'Whether to apply invalid style or not.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    disabled: {
+        name: 'disabled',
+        type: { name: 'boolean' },
+        description: 'Whether to disable selection or not.',
+        defaultValue: false,
+        table: {
+            type: {
+                summary: 'boolean',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'false',
+            },
+        },
+        control: {
+            type: 'boolean',
         },
     },
     handler: {
@@ -62,69 +132,33 @@ const extraArgTypes: ArgTypes = {
             type: 'boolean',
         },
     },
-    exactMode: {
-        name: 'exactMode',
-        type: { name: 'boolean' },
-        description: 'If it is `true` and there is no exact match for the menu item, the search text will be blank.',
-        defaultValue: true,
+    appearanceType: {
+        name: 'appearanceType',
+        type: { name: 'string' },
+        description: 'Appearance type to display selected items.',
+        defaultValue: FILTERABLE_DROPDOWN_APPEARANCE_TYPES[0],
         table: {
             type: {
-                summary: 'boolean',
+                summary: 'string',
             },
             category: 'props',
             defaultValue: {
-                summary: 'true',
+                summary: `'${FILTERABLE_DROPDOWN_APPEARANCE_TYPES[0]}'`,
             },
         },
         control: {
-            type: 'boolean',
+            type: 'select',
+            options: FILTERABLE_DROPDOWN_APPEARANCE_TYPES,
         },
     },
-    disableDeleteAll: {
-        name: 'disableDeleteAll',
-        type: { name: 'boolean' },
-        description: 'If it is `true`, disable delete all and hide delete all button.',
-        defaultValue: false,
+    pageSize: {
+        name: 'pageSize',
+        type: { name: 'number' },
+        description: 'Page size to show items.',
+        defaultValue: 10,
         table: {
             type: {
-                summary: 'boolean',
-            },
-            category: 'props',
-            defaultValue: {
-                summary: 'false',
-            },
-        },
-        control: {
-            type: 'boolean',
-        },
-    },
-    // context menu fixed style props
-    useFixedMenuStyle: {
-        name: 'useFixedMenuStyle',
-        type: { name: 'boolean' },
-        description: 'Whether to use position fixed style on menu or not. ',
-        defaultValue: false,
-        table: {
-            type: {
-                summary: 'boolean',
-            },
-            category: 'props',
-            defaultValue: {
-                summary: 'false',
-            },
-        },
-        control: {
-            type: 'boolean',
-        },
-    },
-    visibleMenu: {
-        name: 'visibleMenu',
-        type: { name: 'boolean' },
-        description: 'Whether to show the menu or not. Automatically determined if no value is given. `sync` props.',
-        defaultValue: undefined,
-        table: {
-            type: {
-                summary: 'boolean',
+                summary: 'number',
             },
             category: 'props',
             defaultValue: {
@@ -132,7 +166,8 @@ const extraArgTypes: ArgTypes = {
             },
         },
         control: {
-            type: null,
+            type: 'number',
+            options: { min: 0 },
         },
     },
     /* events */
@@ -207,23 +242,85 @@ const extraArgTypes: ArgTypes = {
             type: { summary: null },
         },
     },
-};
-
-const initSearchArgTypes = (): ArgTypes => {
-    const argTypes: ArgTypes = {};
-    const searchArgTypes = getSearchArgTypes();
-    Object.keys(searchArgTypes).forEach((k) => {
-        const item = searchArgTypes[k];
-        if (item.table?.category === 'slots') {
-            argTypes[`search-${k}`] = { ...item, name: `search-${k}` };
-        } else {
-            argTypes[k] = item;
-        }
-        if (['isFocused', 'value'].includes(k)) {
-            item.control = { type: null };
-        }
-    });
-    return argTypes;
+    /* events */
+    onUpdateVisibleMenu: {
+        name: 'update:visible-menu',
+        description: 'Event emitted when menu visibility is updated.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
+    onUpdateSearchText: {
+        name: 'update:search-text',
+        description: 'Event emitted when search text is updated.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
+    onUpdateSelected: {
+        name: 'update:selected',
+        description: 'Event emitted when selected is updated.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
+    onSelect: {
+        name: 'select',
+        description: 'Event emitted when an item is selected.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
+    onDeleteTag: {
+        name: 'delete-tag',
+        description: 'Event emitted when a tag is deleted. It works only when the multiSelectable is true and appearanceType is \'stack\'',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
+    onClickShowMore: {
+        name: 'click-show-more',
+        description: 'Event emitted when \'show more\' item is clicked.',
+        table: {
+            type: {
+                summary: null,
+            },
+            defaultValue: {
+                summary: null,
+            },
+            category: 'events',
+        },
+    },
 };
 
 const initContextMenuArgTypes = (): ArgTypes => {
@@ -233,8 +330,10 @@ const initContextMenuArgTypes = (): ArgTypes => {
         loading: contextMenuArgTypes.loading,
         selected: contextMenuArgTypes.selected,
         multiSelectable: contextMenuArgTypes.multiSelectable,
-        strictSelectMode: contextMenuArgTypes.strictSelectMode,
-        disableDeleteAll: contextMenuArgTypes.disableDeleteAll,
+        searchText: contextMenuArgTypes.searchText,
+        readonly: contextMenuArgTypes.readonly,
+        showSelectHeader: contextMenuArgTypes.showSelectHeader,
+        showSelectMarker: contextMenuArgTypes.showSelectMarker,
     };
     Object.keys(contextMenuArgTypes).forEach((k) => {
         const item = contextMenuArgTypes[k];
@@ -247,6 +346,5 @@ const initContextMenuArgTypes = (): ArgTypes => {
 
 export const getFilterableDropdownArgTypes = (): ArgTypes => ({
     ...extraArgTypes,
-    ...initSearchArgTypes(),
     ...initContextMenuArgTypes(),
 });

--- a/src/inputs/dropdown/filterable-dropdown/type.ts
+++ b/src/inputs/dropdown/filterable-dropdown/type.ts
@@ -1,10 +1,15 @@
 import type { MenuItem } from '@/inputs/context-menu/type';
 
-interface HandlerRes {
-    results: MenuItem[];
+export type FilterableDropdownMenuItem = MenuItem;
+
+export interface HandlerRes {
+    results: FilterableDropdownMenuItem[];
     totalCount?: number;
+    more?: boolean;
 }
-export type AutocompleteHandler = (inputText: string, list: MenuItem[]) => Promise<HandlerRes>|HandlerRes;
+export interface AutocompleteHandler {
+    (inputText: string, pageStart?: number, pageLimit?: number): Promise<HandlerRes>|HandlerRes;
+}
 
 export const FILTERABLE_DROPDOWN_TYPE = Object.freeze({
     default: 'default',
@@ -13,4 +18,5 @@ export const FILTERABLE_DROPDOWN_TYPE = Object.freeze({
 
 export type FILTERABLE_DROPDOWN_TYPE = typeof FILTERABLE_DROPDOWN_TYPE[keyof typeof FILTERABLE_DROPDOWN_TYPE];
 
-export type FilterableDropdownMenuItem = MenuItem;
+export const FILTERABLE_DROPDOWN_APPEARANCE_TYPES = ['basic', 'stack', 'badge'] as const;
+export type FilterableDropdownAppearanceType = typeof FILTERABLE_DROPDOWN_APPEARANCE_TYPES[number];

--- a/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
@@ -84,6 +84,7 @@
                                            :menu="schemaProperty.menuItems"
                                            :selected="rawFormData[schemaProperty.propertyName]"
                                            :multi-selectable="schemaProperty.multiInputMode"
+                                           show-select-marker
                                            use-fixed-menu-style
                                            :invalid="invalid"
                                            class="input-form"


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [x] Tested with console(if usages are changed) 

### Description

#### Basic
https://user-images.githubusercontent.com/26986739/210791051-aab5ecc3-83fc-468a-80de-fb2529ad1cd2.mov

#### Show Select Marker
Removed `showRadioIcon` and added `showSelectMarker` prop.
<img width="723" alt="스크린샷 2023-01-05 오후 9 41 30" src="https://user-images.githubusercontent.com/26986739/210791911-7a7ed895-b225-44f0-9d2e-811711dc05c5.png">
<img width="714" alt="스크린샷 2023-01-05 오후 9 41 43" src="https://user-images.githubusercontent.com/26986739/210791918-fc249ce7-34a1-4f88-bc51-72682639b35f.png">

#### Appearance Type
Added `appearanceType` prop. 
<img width="742" alt="스크린샷 2023-01-05 오후 9 42 11" src="https://user-images.githubusercontent.com/26986739/210791765-7fb095b4-1664-49ef-8ce7-7cda06372c8a.png">
<img width="744" alt="스크린샷 2023-01-05 오후 9 42 16" src="https://user-images.githubusercontent.com/26986739/210791315-c7068bbb-d838-4e25-8610-4fcbd9d0e78e.png">


#### Show Select Header
It does not show select header as default in multi select case.
If you want to enable it, use `showSelectHeader` prop.
<img width="714" alt="스크린샷 2023-01-05 오후 9 42 27" src="https://user-images.githubusercontent.com/26986739/210791951-9797d3fd-fb9b-40a8-adf9-f8a23aea5b5d.png">

#### Using Custom Handler & Loading
Updated `handler` prop.
Use a handler to show the menu with the return value.
So with custom handler, there is no need to give menu prop.
You can control loading manually by loading prop.
If you don't give loading prop, loading UI will be displayed automatically when handler is running.

Handler type:

```typescript
interface HandlerRes {
    results: MenuItem[]; // this is context menu items
    totalCount?: number; // will be deprecated
    more?: boolean; // Whether to show 'show more' item on the bottom or not
}
interface AutocompleteHandler {
    (inputText: string, pageStart?: number, pageLimit?: number): Promise<HandlerRes>|HandlerRes;
}
```

#### Show More & Page Size
Added `pageSize` prop, and show more feature.
When using the handler prop, the first argument of the handler is the input text, the second argument is the pageStart value, and the third argument is the pageLimit.
pageStart and pageLimit are calculated based on the value given to the pageSize prop.

For example, if pageSize is 5, pageStart is initially given 1 and pageLimit is given 5.
If the value of more in the result of executing the handler is true, the show more button is displayed.
When the user presses the show more button, the handler runs again.
At this time, 6 is given as the value of the pageStart argument and 10 is given as the value of the pageLimit argument.


https://user-images.githubusercontent.com/26986739/210792639-4ca84a3d-675e-4653-89ea-2802eb777b32.mov



### Things to Talk About
