### PR TITLE
feat(text-input): add appearance type and use context-menu-controller

### DIFF
--- a/src/hooks/context-menu-controller/index.ts
+++ b/src/hooks/context-menu-controller/index.ts
@@ -102,11 +102,7 @@ export const useContextMenuController = ({
     /* menu capturing */
     const selectedSnapshot = ref<MenuItem[]>([]);
     const capture = () => {
-        if (useMenuFiltering) {
-            selectedSnapshot.value = filterItemsBySearchText(state.searchText, state.selected);
-        } else {
-            selectedSnapshot.value = [...state.selected];
-        }
+        selectedSnapshot.value = [...state.selected];
     };
 
     /* menu attaching */
@@ -114,7 +110,7 @@ export const useContextMenuController = ({
     const {
         attachedMenu,
         attachLoading,
-        resetMenuAndPagination,
+        resetMenuAndPagination: resetAttachedMenuAndPagination,
         attachMenuItems,
     } = useContextMenuAttach({
         attachHandler: handler,
@@ -161,12 +157,12 @@ export const useContextMenuController = ({
         }
     };
     const initiateMenu = async () => {
-        resetMenuAndPagination();
+        resetAttachedMenuAndPagination();
         capture();
         await attachMenuItems();
     };
     const reloadMenu = async () => {
-        resetMenuAndPagination();
+        resetAttachedMenuAndPagination();
         await attachMenuItems();
     };
 

--- a/src/inputs/context-menu/type.ts
+++ b/src/inputs/context-menu/type.ts
@@ -18,4 +18,5 @@ export interface MenuItem {
     link?: string;
     target?: string;
     icon?: string;
+    error?: boolean;
 }

--- a/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
+++ b/src/inputs/dropdown/filterable-dropdown/PFilterableDropdown.vue
@@ -95,7 +95,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { vOnClickOutside } from '@vueuse/components';
 import { useFocus } from '@vueuse/core';
-import { debounce, reduce } from 'lodash';
+import { debounce, isEqual, reduce } from 'lodash';
 
 import PBadge from '@/data-display/badges/PBadge.vue';
 import PTag from '@/data-display/tags/PTag.vue';
@@ -160,7 +160,7 @@ const emit = defineEmits<{(e: 'update:visible-menu', visibleMenu: boolean): void
 /* selection */
 const proxySelected = ref<MenuItem[]>(props.selected);
 const updateSelected = (selected: MenuItem[]) => {
-    if (proxySelected.value !== selected && !(proxySelected.value.length === 0 && selected.length === 0)) {
+    if (proxySelected.value !== selected && !isEqual(proxySelected.value, selected)) {
         proxySelected.value = selected;
         emit('update:selected', selected);
     }

--- a/src/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-button-display.ts
+++ b/src/inputs/dropdown/filterable-dropdown/composables/filterable-dropdown-button-display.ts
@@ -10,7 +10,7 @@ import { i18n } from '@/translations';
 interface UseDropdownButtonDisplay {
     multiSelectable: Ref<boolean|undefined>;
     selected: Ref<FilterableDropdownMenuItem[]>;
-    appearanceType: Ref<FilterableDropdownAppearanceType>;
+    appearanceType: Ref<FilterableDropdownAppearanceType|undefined>;
     placeholder: Ref<string|undefined>;
 }
 export const useFilterableDropdownButtonDisplay = ({

--- a/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
+++ b/src/inputs/forms/json-schema-form/PJsonSchemaForm.vue
@@ -102,7 +102,7 @@
                                       :type="schemaProperty.inputType"
                                       :invalid="invalid"
                                       :placeholder="schemaProperty.inputPlaceholder"
-                                      :masking-mode="schemaProperty.inputType === 'password'"
+                                      :appearance-type="schemaProperty.appearanceType"
                                       :autocomplete="false"
                                       :disabled="schemaProperty.disabled"
                                       :multi-input="schemaProperty.multiInputMode"
@@ -136,6 +136,7 @@ import { useLocalize } from '@/inputs/forms/json-schema-form/composables/localiz
 import { useValidation } from '@/inputs/forms/json-schema-form/composables/validation';
 import { addCustomFormats, addCustomKeywords } from '@/inputs/forms/json-schema-form/custom-schema';
 import {
+    getAppearanceType,
     getComponentNameBySchemaProperty,
     getInputPlaceholderBySchemaProperty,
     getInputTypeBySchemaProperty, getMenuItemsBySchemaProperty, getMultiInputMode,
@@ -226,6 +227,7 @@ export default defineComponent<JsonSchemaFormProps>({
                             inputPlaceholder: getInputPlaceholderBySchemaProperty(schemaProperty),
                             menuItems: getMenuItemsBySchemaProperty(schemaProperty),
                             multiInputMode: getMultiInputMode(schemaProperty),
+                            appearanceType: getAppearanceType(schemaProperty),
                         };
                         return refined;
                     }).sort((a, b) => {

--- a/src/inputs/forms/json-schema-form/helper.ts
+++ b/src/inputs/forms/json-schema-form/helper.ts
@@ -2,6 +2,7 @@ import type { SelectDropdownMenu } from '@/inputs/dropdown/select-dropdown/type'
 import type {
     ComponentName, InnerJsonSchema, JsonSchema, TextInputType,
 } from '@/inputs/forms/json-schema-form/type';
+import type { InputAppearanceType } from '@/inputs/input/type';
 
 export const NUMERIC_TYPES = ['number', 'integer'];
 
@@ -157,4 +158,13 @@ export const getMenuItemsBySchemaProperty = (schemaProperty: InnerJsonSchema): S
 export const getMultiInputMode = (schemaProperty: InnerJsonSchema): boolean => {
     if (schemaProperty.type !== 'array') return false;
     return schemaProperty?.maxItems !== 1;
+};
+
+export const getAppearanceType = (schemaProperty: InnerJsonSchema): InputAppearanceType|undefined => {
+    if (getInputTypeBySchemaProperty(schemaProperty) === 'password') return 'masking';
+    if (getComponentNameBySchemaProperty(schemaProperty) === 'PTextInput') {
+        if (schemaProperty.type === 'array') return 'stack';
+        return 'basic';
+    }
+    return undefined;
 };

--- a/src/inputs/forms/json-schema-form/type.ts
+++ b/src/inputs/forms/json-schema-form/type.ts
@@ -1,6 +1,7 @@
 import type { JSONSchemaType } from 'ajv';
 
 import type { SelectDropdownMenu } from '@/inputs/dropdown/select-dropdown/type';
+import type { InputAppearanceType } from '@/inputs/input/type';
 import type { SupportLanguage } from '@/translations';
 
 const TEXT_INPUT_TYPES = ['password', 'text', 'number'] as const;
@@ -26,6 +27,7 @@ export type InnerJsonSchema = JsonSchema & {
     inputPlaceholder?: string;
     menuItems?: SelectDropdownMenu[];
     multiInputMode?: boolean;
+    appearanceType?: InputAppearanceType;
 };
 
 export interface JsonSchemaFormProps {

--- a/src/inputs/input/PTextInput.stories.mdx
+++ b/src/inputs/input/PTextInput.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import Fuse from 'fuse.js'
 import PTextInput from '@/inputs/input/PTextInput.vue';
 import PButton from "@/inputs/buttons/button/PButton";
 import PTextEditor from "@/inputs/text-editor/PTextEditor";
@@ -7,7 +8,7 @@ import { reactive, toRefs } from 'vue';
 import {
     getTextInputArgTypes
 } from "@/inputs/input/story-helper";
-import {getTextInputMenu} from "@/inputs/input/mock";
+import {getTextInputMenu, getTextInputMenuWithMultiTypes} from "@/inputs/input/mock";
 import {INPUT_SIZE} from "@/inputs/input/type";
 
 
@@ -23,14 +24,18 @@ export const Template = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { PTextInput },
     template: `
-        <p-text-input v-bind="inputAttrs"
-                      :value="value" :invalid="invalid"
-                      :disabled="disabled" :block="block"
-                      :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
-                      :loading="loading"
-                      :masking-mode="maskingMode"
-                      :show-password="showPassword"
-                      :size="size"
+        <p-text-input
+                    v-bind="inputAttrs"
+                    :value="value"
+                    :size="size"
+                    :invalid="invalid"
+                    :disabled="disabled" :block="block"
+                    :menu="menu" :use-fixed-menu-style="useFixedMenuStyle"
+                    :loading="loading"
+                    :show-password="showPassword"
+                    :appearance-type="appearanceType"
+                    :input-mode="inputMode"
+                    :page-size="pageSize"
         >
             <template v-if="inputRightSlot" #input-right>
                 <span v-html="inputRightSlot"></span>
@@ -74,14 +79,21 @@ export const Template = (args, { argTypes }) => ({
 <br/>
 <br/>
 
-## Autocomplete Multiple Input
+## Autocomplete
 <Canvas>
-    <Story name="Autocomplete Multiple Input">
+    <Story name="Autocomplete">
         {{
             components: { PTextInput },
             template: `
-                <div>
-                    <p-text-input :menu="menu" :selected.sync="selected" multi-input use-fixed-menu-style use-auto-complete />
+                <div style="width: 90%">
+                    <p class="text-label-lg font-bold my-3">With single input</p>
+                    <p-text-input :menu="menu" :selected.sync="selected" use-auto-complete use-fixed-menu-style />
+                    <br/>
+                    <br/>
+                    <p class="text-label-lg font-bold my-3">With multi input</p>
+                    <p-text-input :menu="menu" :selected.sync="selected" multi-input use-auto-complete use-fixed-menu-style />
+                    <br/>
+                    <br/>
                     <div class="flex mt-4">
                         <div class="mr-4 p-4 bg-blue-100 w-full max-h-64 overflow-y-auto">
                             <p class="font-lg font-bold">menu: </p>
@@ -100,6 +112,134 @@ export const Template = (args, { argTypes }) => ({
                     selected: []
                 })
                 return toRefs(state)
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+
+## Multi Input Duplicate Checks
+
+If there are duplicated items in `selected`, It shows invalid style to the duplicated tags. <br/>
+It does not perform duplicate checks on `item.label`. <br/>
+Please note that only `item.name` is checked for duplicates. <br/>
+If you want to get the result of duplicate check, use `update` event. <br/>
+`update` event's first argument is updated `selected` and the second argument is `boolean` which indicates is valid(no duplicated items) or not. <br/>
+
+
+<Canvas>
+    <Story name="Multi Input Duplicate Checks">
+        {{
+            components: { PTextInput },
+            template: `
+                <div style="width: 80%">
+                    <p-text-input :selected.sync="selected" multi-input use-fixed-menu-style @update="handleUpdate" />
+                    <div class="flex mt-4">
+                        <div class="p-4 w-full max-h-64 overflow-y-auto" :class="isValid ? 'bg-green-200' : 'bg-coral-200'">
+                            <p class="font-lg font-bold">isValid: </p>
+                            <pre>{{isValid}}</pre>
+                        </div>
+                        <div class="p-4 bg-blue-200 w-full max-h-64 overflow-y-auto">
+                            <p class="font-lg font-bold">selected: </p>
+                            <pre>{{selected}}</pre>
+                        </div>
+                    </div>
+                </div>
+            `,
+            setup() {
+                const state = reactive({
+                    selected: [{name: 'a', label: 'A'}, {name: 'b', label: 'B'}, {name: 'a', label: 'A'}, {name: 'bb', label: 'B'}],
+                    isValid: false,
+                })
+                const handleUpdate = (_, isValid) => {
+                    state.isValid = isValid;
+                }
+                return {
+                    ...toRefs(state),
+                    handleUpdate
+                }
+            }
+        }}
+    </Story>
+</Canvas>
+
+<br/>
+<br/>
+
+## Autocomplete with Page Size
+When using the `handler` prop, the first argument of the handler is the input text, the second argument is the pageStart value, and the third argument is the pageLimit. <br/>
+pageStart and pageLimit are calculated based on the value given to the `pageSize` prop. <br/>
+
+For example, if `pageSize` is 5, pageStart is initially given 1 and pageLimit is given 5. <br/>
+If the value of more in the result of executing the handler is true, the show more button is displayed. <br/>
+When the user presses the show more button, the handler runs again. <br/>
+At this time, 6 is given as the value of the pageStart argument and 10 is given as the value of the pageLimit argument. <br/>
+
+<Canvas>
+    <Story name="Autocomplete with Page Size">
+        {{
+            components: { PTextInput },
+            template: `
+                <div>
+                    <p class="text-label-lg font-bold my-3">With page size 5</p>
+                    <p-text-input :menu="menu" :selected.sync="selected" use-auto-complete :page-size="5" use-fixed-menu-style />
+                    <br/>
+                    <br/>
+                    <p class="text-label-lg font-bold my-3">With multi input, page size 5</p>
+                    <p-text-input :menu="menu" :selected.sync="selected" use-auto-complete multi-input :page-size="5" use-fixed-menu-style />
+                    <br/>
+                    <br/>
+                    <p class="text-label-lg font-bold my-3">With custom handler, page size 5</p>
+                    <p-text-input :selected.sync="selected" :handler="simpleHandler" use-auto-complete :page-size="5" use-fixed-menu-style />
+                    <br/>
+                    <br/>
+                    <p class="text-label-lg font-bold my-3">With custom handler, multi input, page size 5</p>
+                    <p-text-input :selected.sync="selected" :handler="simpleHandler" use-auto-complete multi-input :page-size="5" use-fixed-menu-style />
+                    <br/>
+                    <br/>
+                    <div class="p-4 bg-blue-200 w-full max-h-64 overflow-y-auto">
+                        <p class="font-lg font-bold">selected: </p>
+                        <pre>{{selected}}</pre>
+                    </div>
+                </div>
+            `,
+            setup() {
+                const state = reactive({
+                    menu: getTextInputMenu(),
+                    selected: []
+                })
+                const menu = getTextInputMenuWithMultiTypes()
+                let allResults = []
+                const simpleHandler = async (inputText) => {
+                    state.loading = true;
+                    allResults = await new Promise(resolve => {
+                        setTimeout(() => {
+                            let filtered;
+                            const trimmed = inputText.trim();
+                            if (trimmed) {
+                                filtered = new Fuse(menu, {
+                                    keys: ['label'],
+                                    distance: 100,
+                                    threshold: 0.1,
+                                    ignoreLocation: true,
+                                }).search(trimmed);
+                            } else {
+                                filtered = [...menu]
+                            }
+                            resolve(filtered)
+                        }, 500)
+                    })
+                    state.loading = false;
+                    const results = allResults.slice(0, 5)
+                    return { results, more: allResults.length > results.length }
+                }
+                return {
+                    ...toRefs(state),
+                    simpleHandler
+                }
             }
         }}
     </Story>
@@ -163,7 +303,17 @@ export const Template = (args, { argTypes }) => ({
         {{
             components: { PTextInput },
             template: `
-                <p-text-input v-model="value" type="password" />
+            <div>
+                <p class="text-label-lg font-bold my-3">With 'password' input type</p>
+                <p-text-input value="password" type="password" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">With 'password' input type, with 'masking' appearance type</p>
+                <p-text-input value="password" type="password" appearance-type="masking" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">With 'password' input type, with 'masking' appearance type, with \`showPassword\` false</p>
+                <p-text-input value="password" type="password" appearance-type="masking" :show-password="false" />
+                <br/>
+            </div>
             `,
             setup() {
                 const state = reactive({
@@ -177,18 +327,42 @@ export const Template = (args, { argTypes }) => ({
     </Story>
 </Canvas>
 
-#### Masking Mode
+<br/>
+<br/>
+
+## Appearance Type
 
 <Canvas>
-    <Story name="Masking Mode">
+    <Story name="Appearance Type">
         {{
             components: { PTextInput },
             template: `
-                <p-text-input v-model="value" type="password" masking-mode />
+            <div>
+                <p class="text-label-lg font-bold my-3">Single input with 'basic', 'badge', 'stack' appearance type</p>
+                <p-text-input value="hello" appearance-type="basic" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Single input with 'masking' appearance type, 'password' input type</p>
+                <p-text-input value="password" appearance-type="masking" type="password" />
+                <br/>
+                <br/>
+                <hr/>
+                <br/>
+                <p class="text-label-lg font-bold my-3">Multi input with 'badge' appearance type</p>
+                <p-text-input :menu="menu" :selected="selected" multi-input use-auto-complete appearance-type="badge" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Multi input with 'stack' appearance type</p>
+                <p-text-input :menu="menu" :selected="selected" multi-input use-auto-complete appearance-type="stack" />
+                <br/>
+                <p class="text-label-lg font-bold my-3">Multi input with 'basic', 'masking' appearance type - it doesn't work</p>
+                <p-text-input :menu="menu" :selected="selected" multi-input appearance-type="masking" />
+                <br/>
+            </div>
             `,
             setup() {
+                const items = getTextInputMenu()
                 const state = reactive({
-                    value: 'password'
+                    menu: items,
+                    selected: items.slice(0, 3)
                 })
                 return {
                     ...toRefs(state)

--- a/src/inputs/input/composables/use-input-deletion.ts
+++ b/src/inputs/input/composables/use-input-deletion.ts
@@ -1,0 +1,56 @@
+import type { Ref } from 'vue';
+import { ref } from 'vue';
+
+import type { InputItem } from '@/inputs/input/type';
+
+interface UseInputDeletionOption {
+    selected: Ref<InputItem[]>;
+    updateInputValue: (value?: string|number) => void;
+    updateSelected: (selected: InputItem[]) => void;
+    isInputValueEmpty: Ref<boolean>;
+}
+export const useInputDeletion = ({
+    selected, updateInputValue, updateSelected, isInputValueEmpty,
+}: UseInputDeletionOption) => {
+    const deleteTarget = ref<InputItem|undefined>(undefined);
+    const deleteTargetIdx = ref<number>(-1);
+    const deleteSelectedValue = () => {
+        const item = selected.value[0];
+        if (!item) return;
+        updateInputValue(['string', 'number'].includes(typeof item.label) ? item.label as string : item.name);
+        updateSelected([]);
+    };
+    const deleteTargetTag = () => {
+        if (!isInputValueEmpty.value) return;
+        const lastIdx = selected.value.length - 1;
+        if (deleteTargetIdx.value === -1) { // Select the item if there is no selection
+            deleteTargetIdx.value = lastIdx;
+            deleteTarget.value = selected.value[lastIdx];
+            return;
+        }
+
+        const targetIdx = deleteTargetIdx.value;
+        const targetTag = selected.value[targetIdx];
+
+        if (!targetTag) updateSelected([]);
+        deleteTag(targetTag, targetIdx);
+    };
+    const deleteTag = (tag: InputItem, idx: number) => {
+        const _selectedItems: InputItem[] = [...selected.value];
+        _selectedItems.splice(idx, 1);
+        updateSelected(_selectedItems);
+        deleteTargetIdx.value = -1;
+        deleteTarget.value = undefined;
+    };
+    const deleteAll = () => {
+        updateSelected([]);
+        updateInputValue('');
+    };
+    return {
+        deleteTargetIdx,
+        deleteSelectedValue,
+        deleteTargetTag,
+        deleteTag,
+        deleteAll,
+    };
+};

--- a/src/inputs/input/composables/use-query-input.ts
+++ b/src/inputs/input/composables/use-query-input.ts
@@ -1,0 +1,423 @@
+import type { WatchStopHandle, Ref } from 'vue';
+import {
+    computed, onMounted, onUnmounted, reactive, ref, watch,
+} from 'vue';
+
+import {
+    cloneDeep, debounce, find, throttle,
+} from 'lodash';
+
+import {
+    defaultHandlerMap, formatterMap,
+    inputTypeMap, inputValidatorMap,
+    menuTypeMap,
+    placeholderMap,
+    supportOperatorMap,
+} from '@/inputs/search/query-search/config';
+import {
+    findKey, getKeyMenuForm, getRootKeyItemHandler, getValueMenuForm,
+} from '@/inputs/search/query-search/helper';
+import { OPERATOR, operators } from '@/inputs/search/query-search/type';
+import type {
+    KeyItem, OperatorType, KeyDataType,
+    HandlerResponse, MenuType, ValueHandler,
+    KeyMenuItem, ValueMenuItem,
+    QueryItem, ValueItem, KeyItemSet, ValueHandlerMap,
+} from '@/inputs/search/query-search/type';
+
+const ROOT_KEY_SETTER = ':';
+const NUMBER_TYPES = ['integer', 'float'];
+
+export interface UseQueryInputOptions {
+    focused: boolean;
+    value?: Ref<string>;
+    keyItemSets: Ref<KeyItemSet[]>;
+    valueHandlerMap: Ref<ValueHandlerMap>;
+    visibleMenu: Ref<boolean | undefined>;
+}
+
+export const usQueryInput = ({
+    value, focused, visibleMenu, valueHandlerMap, keyItemSets,
+}: UseQueryInputOptions) => {
+    const state = reactive({
+        /* Args */
+        keyItemSets,
+        valueHandlerMap,
+
+        /* Input */
+        isFocused: focused,
+        searchText: value || ref(''),
+        inputRef: null as null|HTMLElement,
+        currentPlaceholder: computed(() => placeholderMap[state.currentDataType] || undefined),
+        inputElType: computed(() => inputTypeMap[state.currentDataType] || 'text'),
+        currentDataType: computed<KeyDataType|string>(() => {
+            if (state.selectedKeys.length > 1) return state.handlerResp.dataType || '';
+            if (state.rootKey) return state.rootKey.dataType || '';
+            return '';
+        }),
+
+        /* Query */
+        selectedKeys: [] as KeyItem[],
+        subPath: computed<string|undefined>(() => state.selectedKeys.slice(1).map((d) => d.name).join('.') || undefined),
+        selectedKey: computed<KeyItem|null>(() => state.selectedKeys[state.selectedKeys.length - 1] || null),
+        rootKey: computed<KeyItem|null>(() => state.selectedKeys[0] || null),
+        operator: OPERATOR.contain as OperatorType,
+        supportOperators: computed<OperatorType[]>(() => {
+            if (state.handlerResp.operators) return state.handlerResp.operators;
+            if (state.rootKey?.operators) return state.rootKey.operators;
+            if (supportOperatorMap[state.currentDataType]) return supportOperatorMap[state.currentDataType];
+            return operators;
+        }),
+
+        /* Menu */
+        menuRef: null as any,
+        visibleMenu,
+        menuType: computed<MenuType>(() => {
+            if (!state.rootKey) return 'ROOT_KEY';
+            if (state.currentDataType === 'object') return 'KEY';
+            return menuTypeMap[state.currentDataType] || 'VALUE';
+        }),
+        menu: [] as Array<KeyMenuItem|ValueMenuItem>,
+
+        /* Handler */
+        loading: false,
+        lazyLoading: false,
+        handler: computed<ValueHandler|null>(() => {
+            if (state.menuType === 'ROOT_KEY') return getRootKeyItemHandler(state.keyItemSets);
+            return defaultHandlerMap[state.currentDataType]
+                || state.valueHandlerMap[state.rootKey?.name as string]
+                || null;
+        }),
+        handlerResp: { results: [] } as HandlerResponse,
+    });
+
+    /* Control Input */
+    const focus = () => { state.isFocused = true; };
+    const blur = () => { state.isFocused = false; };
+
+    /* Control Menu */
+    const hideMenu = () => { state.visibleMenu = false; };
+    const showMenu = async (refresh = false) => {
+        state.visibleMenu = true;
+        // eslint-disable-next-line no-use-before-define
+        if (refresh) await updateMenuItems(state.searchText);
+    };
+    let offMenuFocusWatch: WatchStopHandle|undefined;
+    const focusMenu = async (idx = 0) => {
+        if (!state.visibleMenu) await showMenu(true);
+        if (state.menuRef) state.menuRef.focus(idx);
+        else {
+            if (offMenuFocusWatch) offMenuFocusWatch();
+            offMenuFocusWatch = watch(() => state.menuRef, (menuRef) => {
+                if (menuRef) {
+                    menuRef.focus(idx);
+                    if (offMenuFocusWatch) offMenuFocusWatch();
+                }
+            });
+        }
+    };
+
+    /* Control Input */
+    const leaveSearch = () => {
+        blur();
+        hideMenu();
+    };
+    const clearAll = () => {
+        state.searchText = '';
+        state.operator = OPERATOR.contain;
+    };
+    const updateOperator = (operator?: OperatorType) => {
+        if (operator === undefined) {
+            if (state.operator.length === 2) state.operator = state.operator.substring(0, 1) as OperatorType;
+            else state.operator = OPERATOR.contain;
+        } else {
+            state.operator = operator;
+        }
+    };
+    const findAndSetKey = async (val: string, isRootKey = true) => {
+        let item = findKey(val, state.handlerResp.results) || null;
+        if (isRootKey) {
+            if (item) {
+                clearAll();
+                focus();
+                updateSelectedKey(item, true);
+                await updateMenuItems(state.searchText);
+            }
+        } else {
+            if (!item) item = { label: val, name: val };
+            clearAll();
+            focus();
+            updateSelectedKey(item);
+            await updateMenuItems(state.searchText);
+        }
+    };
+
+    /* Control Menu Loading */
+    const updateLoader = debounce(() => {
+        state.lazyLoading = state.loading;
+    }, 500);
+    const updateLoading = (loading, force = false) => {
+        state.loading = loading;
+        if (force) state.lazyLoading = loading;
+        else if (state.lazyLoading !== state.loading) updateLoader();
+    };
+
+    /* Menu Setting */
+    const updateSelectedKey = (item: KeyItem|null, replace = false) => {
+        if (replace) {
+            if (item) state.selectedKeys = [item];
+            else state.selectedKeys = [];
+        } else if (item) state.selectedKeys.push(item);
+        else state.selectedKeys.pop();
+    };
+    const setMenu = (res: HandlerResponse) => {
+        if (state.menuType === 'ROOT_KEY') state.menu = res.results;
+        else if (state.menuType === 'KEY') state.menu = getKeyMenuForm({ menuResponse: res, selectedKeys: state.selectedKeys, subPath: state.subPath });
+        else if (state.menuType === 'VALUE') {
+            state.menu = getValueMenuForm({
+                menuResponse: res,
+                selectedKeys: state.selectedKeys,
+                operator: state.operator,
+                subPath: state.subPath,
+                hideKey: strict,
+            });
+        } else state.menu = res.results.map((d) => ({ ...d, type: 'item', data: d }));
+        if (!state.menu.length) hideMenu();
+    };
+    const updateMenuItems = throttle(async (inputText: string): Promise<void> => {
+        let res: HandlerResponse = { results: [] };
+        updateLoading(true);
+
+        const input = NUMBER_TYPES.includes(state.currentDataType) ? Number(inputText) : inputText;
+        if (state.handler) {
+            const func = state.handler(
+                input,
+                state.rootKey as KeyItem,
+                state.currentDataType,
+                state.subPath,
+                state.operator,
+            );
+            if (func instanceof Promise) {
+                res = await func;
+            } else {
+                res = func;
+            }
+        }
+
+        state.handlerResp = res;
+        setMenu(res);
+        updateLoading(false, true);
+    }, 150);
+
+    /* Utils */
+    const getKeyItemsFromKeyText = (keyStr: string): KeyItem[] => {
+        const allKeyItems = state.keyItemSets.map((d) => d.items).flat();
+        const dotIdx = keyStr.indexOf('.');
+        let keyItems: KeyItem[] = [];
+
+        if (dotIdx === -1) {
+            const item = findKey(keyStr, allKeyItems);
+            if (item) keyItems.push(item);
+        } else {
+            const item = findKey(keyStr.slice(0, dotIdx), allKeyItems);
+            if (item?.dataType === 'object') {
+                keyItems = keyStr.split('.').map((d, i) => (i === 0 ? item : { label: d, name: d }));
+            } else if (item) keyItems.push(item);
+        }
+
+        return keyItems;
+    };
+    const onDelete = async (e) => {
+        if (e.target.value) return;
+
+        if (state.operator) {
+            updateOperator();
+            await updateMenuItems(state.searchText);
+        } else if (state.selectedKey) {
+            updateSelectedKey(null);
+            await updateMenuItems('');
+        }
+    };
+
+    const refineQueryItem = (valueItem: ValueItem): QueryItem | undefined => {
+        let queryItem: QueryItem|null = {
+            key: state.rootKey,
+            value: valueItem,
+            operator: strict ? '=' : state.operator ?? undefined,
+        };
+
+        if (formatterMap[state.rootKey?.dataType]) {
+            queryItem = formatterMap[state.rootKey.dataType](cloneDeep(queryItem), state.currentDataType, state.subPath);
+        }
+
+        if (queryItem) {
+            clearAll();
+            if (state.selectedKey) updateSelectedKey(null, true);
+            hideMenu();
+            return queryItem;
+        }
+
+        return undefined;
+    };
+
+    /* Event handlers */
+    const onInput = async (e) => {
+        const val = e.target.value === null || e.target.value === undefined ? '' : e.target.value;
+        state.searchText = val;
+
+        if (!state.visibleMenu) await showMenu();
+
+        if (val.length > 1 && e.data === ROOT_KEY_SETTER && !state.rootKey) await findAndSetKey(val.slice(0, val.length - 1));
+        else await updateMenuItems(val);
+    };
+
+    // TODO: need to refactor
+    const onKeyupEnter = async (): Promise<QueryItem | undefined> => {
+        if (strict) {
+            const res = find(state.handlerResp.results, (item: ValueMenuItem) => item.label === state.searchText || item.name === state.searchText);
+            if (res) {
+                if (state.rootKey) return refineQueryItem(res);
+                await findAndSetKey(state.searchText);
+            }
+        } else if (state.currentDataType === 'object') {
+            if (state.searchText) await findAndSetKey(state.searchText, false);
+        } else if (state.rootKey) {
+            // In null case, only '=', '!=' operators are available.
+            if (state.searchText === '') {
+                if (state.operator.startsWith('!')) {
+                    state.operator = '!=';
+                } else state.operator = '=';
+                return refineQueryItem({ label: 'Null', name: null });
+            }
+            return refineQueryItem({ label: state.searchText, name: state.searchText });
+        } else if (state.searchText) {
+            return refineQueryItem({ label: state.searchText, name: state.searchText });
+        }
+
+        return undefined;
+    };
+
+    const onKeydownCheck = async (e: KeyboardEvent) => {
+        if (e.key === 'Backspace') {
+            await onDelete(e);
+            return;
+        }
+        if (e.key === 'ArrowDown' || e.key === 'Down') {
+            await focusMenu();
+            return;
+        }
+        if (e.key === 'ArrowUp' || e.key === 'Up') {
+            await focusMenu(-1);
+            return;
+        }
+        if (e.key === 'Escape' || e.key === 'Esc') {
+            leaveSearch();
+            return;
+        }
+
+        if (!state.selectedKey) return;
+
+        /* check operator */
+        if (state.searchText.length === 0 && !strict) {
+            const op = state.operator + e.key;
+            if (state.supportOperators.some((d) => d.startsWith(op))) {
+                e.preventDefault();
+                updateOperator(op as OperatorType);
+                await updateMenuItems(state.searchText);
+            } else if (!state.supportOperators.includes(state.operator)) {
+                updateOperator('');
+                if (state.operator !== '') await updateMenuItems(state.searchText);
+            }
+        }
+
+        /* value validation */
+        if (inputValidatorMap[state.currentDataType]) {
+            const validator = inputValidatorMap[state.currentDataType];
+            if (!validator(e.key)) e.preventDefault();
+        }
+    };
+    const onPaste = (e: ClipboardEvent) => {
+        if (state.selectedKeys.length > 0) return;
+
+        const paste: string = (e.clipboardData || (window as any).clipboardData).getData('text');
+        const text = (state.searchText + paste).trim().replace(/(\r\n|\n|\r)/gm, '');
+
+        const separatorIdx = text.indexOf(':');
+        if (separatorIdx === -1) {
+            state.searchText = text;
+        } else {
+            const keyStr = text.slice(0, separatorIdx);
+            const keyItems = getKeyItemsFromKeyText(keyStr);
+
+            const textValue = text.slice(separatorIdx + 1);
+            if (keyItems.length > 0) {
+                state.selectedKeys = keyItems;
+                state.searchText = textValue;
+                hideMenu();
+            } else {
+                state.searchText = text;
+            }
+        }
+
+        e.preventDefault();
+    };
+    const onDeleteAll = async () => {
+        updateSelectedKey(null, true);
+        clearAll();
+        await updateMenuItems(state.searchText);
+        focus();
+    };
+    const preTreatSelectedMenuItem = async (item: KeyMenuItem|ValueMenuItem): Promise<QueryItem | undefined> => {
+        if (state.menuType === 'ROOT_KEY' || state.menuType === 'KEY') {
+            hideMenu();
+            updateSelectedKey(item.data as KeyItem);
+            clearAll();
+            focus();
+            await showMenu(true);
+        } else if (state.menuType === 'OPERATOR') {
+            const operator = item.name as OperatorType;
+            if (state.supportOperators.includes(operator)) {
+                updateOperator(operator);
+                focus();
+                hideMenu();
+            }
+        } else {
+            if (!state.operator) state.operator = OPERATOR.equal;
+            const queryItem = refineQueryItem(item.data as ValueItem);
+            return queryItem;
+        }
+
+        return undefined;
+    };
+
+    /* Window Events Binding */
+    const onWindowKeydown = (e: KeyboardEvent) => {
+        if (state.visibleMenu && ['ArrowDown', 'ArrowUp'].includes(e.code)) {
+            e.preventDefault();
+        }
+    };
+    onMounted(() => {
+        window.addEventListener('keydown', onWindowKeydown, false);
+    });
+    onUnmounted(() => {
+        window.removeEventListener('keydown', onWindowKeydown, false);
+    });
+
+    return {
+        state,
+
+        // UI controllers
+        focus,
+        blur,
+        hideMenu,
+        showMenu,
+
+        // event handlers
+        onInput,
+        onKeyupEnter,
+        onKeydownCheck,
+        onPaste,
+        onDeleteAll,
+        preTreatSelectedMenuItem,
+    };
+};

--- a/src/inputs/input/composables/use-selected-validation.ts
+++ b/src/inputs/input/composables/use-selected-validation.ts
@@ -1,0 +1,32 @@
+import type { Ref } from 'vue';
+import { computed } from 'vue';
+
+import type { InputItem } from '@/inputs/input/type';
+
+interface UseSelectedValidationOptions {
+    selected: Ref<InputItem[]>
+}
+export const useSelectedValidation = ({
+    selected,
+}: UseSelectedValidationOptions) => {
+    const isSelectedInvalid = computed(() => Object.values<number[]>(selectedIndicesMap.value).some((indices) => indices.length > 1));
+    const selectedIndicesMap = computed<Record<string, number[]>>(() => {
+        const result = {};
+        selected.value.forEach((item, idx) => {
+            if (result[item.name]) {
+                result[item.name].push(idx);
+            } else {
+                result[item.name] = [idx];
+            }
+        });
+        return result;
+    });
+    const isSelectedItemInvalid = (tag: InputItem, index: number) => {
+        if (tag.error) return true;
+        return selectedIndicesMap.value[tag.name].length > 0 && selectedIndicesMap.value[tag.name][0] !== index;
+    };
+    return {
+        isSelectedInvalid,
+        isSelectedItemInvalid,
+    };
+};

--- a/src/inputs/input/mock.ts
+++ b/src/inputs/input/mock.ts
@@ -1,7 +1,9 @@
 import { faker } from '@faker-js/faker';
 import { range } from 'lodash';
 
-const getMenuItem = () => ({
+import type { MenuItem } from '@/inputs/context-menu/type';
+
+const getMenuItem = (): MenuItem => ({
     name: faker.datatype.uuid(),
     label: `${faker.random.word()}`, // (${faker.random.word()})`,
     type: 'item',
@@ -9,3 +11,14 @@ const getMenuItem = () => ({
 });
 
 export const getTextInputMenu = (min = 10, max = 30) => range(faker.datatype.number({ min, max })).map(() => getMenuItem());
+export const getTextInputMenuWithMultiTypes = (): MenuItem[] => range(30).map((i) => {
+    const result = getMenuItem();
+
+    if ([0, 10, 20].includes(i)) {
+        result.type = 'header';
+    } else if ([1, 11, 21].includes(i)) {
+        result.type = 'divider';
+    }
+
+    return result;
+});

--- a/src/inputs/input/story-helper.ts
+++ b/src/inputs/input/story-helper.ts
@@ -1,7 +1,7 @@
 import type { ArgTypes } from '@storybook/addons';
 
 import { getContextMenuArgTypes } from '@/inputs/context-menu/story-helper';
-import { INPUT_SIZE } from '@/inputs/input/type';
+import { INPUT_APPEARANCE_TYPES, INPUT_SIZE, INPUT_MODES } from '@/inputs/input/type';
 
 const initContextMenuArgTypes = (): ArgTypes => {
     const contextMenuArgTypes = getContextMenuArgTypes();
@@ -31,6 +31,25 @@ export const getTextInputArgTypes = (): ArgTypes => {
             },
             control: {
                 type: 'text',
+            },
+        },
+        size: {
+            name: 'size',
+            type: { name: 'string' },
+            description: `TextInput size. ${Object.values(INPUT_SIZE)} are available.`,
+            defaultValue: INPUT_SIZE.md,
+            table: {
+                type: {
+                    summary: 'string',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: `"${INPUT_SIZE.md}"`,
+                },
+            },
+            control: {
+                type: 'select',
+                options: Object.values(INPUT_SIZE),
             },
         },
         disabled: {
@@ -212,24 +231,6 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
-        exactMode: {
-            name: 'exactMode',
-            type: { name: 'boolean' },
-            description: 'If it is `true` and there is no exact match for the menu item, the search text will be blank.',
-            defaultValue: true,
-            table: {
-                type: {
-                    summary: 'boolean',
-                },
-                category: 'props',
-                defaultValue: {
-                    summary: 'true',
-                },
-            },
-            control: {
-                type: 'boolean',
-            },
-        },
         useAutoComplete: {
             name: 'useAutoComplete',
             type: { name: 'boolean' },
@@ -284,23 +285,61 @@ export const getTextInputArgTypes = (): ArgTypes => {
                 type: 'boolean',
             },
         },
-        size: {
-            name: 'size',
+        appearanceType: {
+            name: 'appearanceType',
             type: { name: 'string' },
-            description: `TextInput size. ${Object.values(INPUT_SIZE)} are available.`,
-            defaultValue: INPUT_SIZE.md,
+            description: 'Appearance type to display selected items.',
+            defaultValue: INPUT_APPEARANCE_TYPES[0],
             table: {
                 type: {
                     summary: 'string',
                 },
                 category: 'props',
                 defaultValue: {
-                    summary: `"${INPUT_SIZE.md}"`,
+                    summary: `'${INPUT_APPEARANCE_TYPES[0]}'`,
                 },
             },
             control: {
                 type: 'select',
-                options: Object.values(INPUT_SIZE),
+                options: INPUT_APPEARANCE_TYPES,
+            },
+        },
+        inputMode: {
+            name: 'inputMode',
+            type: { name: 'string' },
+            description: 'Input type.',
+            defaultValue: INPUT_MODES[0],
+            table: {
+                type: {
+                    summary: 'string',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: `'${INPUT_MODES[0]}'`,
+                },
+            },
+            control: {
+                type: 'select',
+                options: INPUT_MODES,
+            },
+        },
+        pageSize: {
+            name: 'pageSize',
+            type: { name: 'number' },
+            description: 'Page size to show items.',
+            defaultValue: 10,
+            table: {
+                type: {
+                    summary: 'number',
+                },
+                category: 'props',
+                defaultValue: {
+                    summary: 'undefined',
+                },
+            },
+            control: {
+                type: 'number',
+                options: { min: 0 },
             },
         },
         // attrs
@@ -406,9 +445,23 @@ export const getTextInputArgTypes = (): ArgTypes => {
             },
         },
         // events
-        onInput: {
-            name: 'input',
-            description: 'Event emitted when input something. Works with v-model.',
+        onUpdateValue: {
+            name: 'update:value',
+            description: 'Event emitted when value is updated. Works with v-model, sync.',
+            table: {
+                type: {
+                    summary: null,
+                },
+                defaultValue: {
+                    summary: null,
+                },
+                category: 'events',
+            },
+        },
+        onUpdate: {
+            name: 'update',
+            description: 'Event emitted when selected and duplication check validation is updated. '
+                + 'Selected items are for the first argument, and validation result(boolean) is for the second argument. ',
             table: {
                 type: {
                     summary: null,

--- a/src/inputs/input/type.ts
+++ b/src/inputs/input/type.ts
@@ -1,16 +1,7 @@
-import type { TranslateResult } from 'vue-i18n';
-
 import type { MenuItem } from '@/inputs/context-menu/type';
 
-export interface SelectedItem {
-    value: string;
-    label?: string;
-    invalid?: boolean;
-    invalidText?: string | TranslateResult;
-    duplicated?: boolean;
-}
-export interface TextInputHandler {
-    (val: string, searchableItems: MenuItem[]): Promise<{results: MenuItem[]}>|{results: MenuItem[]}
+export interface InputItem extends MenuItem {
+    name: string;
 }
 
 export const INPUT_SIZE = {
@@ -19,3 +10,18 @@ export const INPUT_SIZE = {
 } as const;
 export type InputSize = typeof INPUT_SIZE[keyof typeof INPUT_SIZE];
 
+
+export const INPUT_APPEARANCE_TYPES = ['basic', 'stack', 'badge', 'masking'] as const;
+export type InputAppearanceType = typeof INPUT_APPEARANCE_TYPES[number];
+
+export const INPUT_MODES = ['plain', 'query'] as const;
+export type InputMode = typeof INPUT_MODES[number];
+
+export interface HandlerRes {
+    results: MenuItem[];
+    totalCount?: number;
+    more?: boolean;
+}
+export interface TextInputHandler {
+    (inputText: string, pageStart?: number, pageLimit?: number): Promise<HandlerRes>|HandlerRes;
+}


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [x] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [x] Tested with console(if usages are changed) 

### Description

![image](https://user-images.githubusercontent.com/26986739/212029544-46ffb45a-ad3a-485a-b8bb-e0125f139aff.png)

- Applied use-context-menu-controller's full features
- Added `appearanceType` (basic, stack, badge, masking)
- Removed `maskingMode`
- Added duplication check logic and added event: `(e: 'selected', selected: InputItem[], isValid: boolean): void;`
- Removed input event
- Updated selected item's type

### Things to Talk About
