### PR TITLE
feat: useSelect on p-board & label event prevent

### DIFF
--- a/src/data-display/board-item/PBoardItem.vue
+++ b/src/data-display/board-item/PBoardItem.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="p-board-item"
-         :class="{'rounded': rounded, 'selected': selected}"
+         :class="{'rounded': rounded, 'selected': isSelected}"
          v-on="$listeners"
     >
         <div class="content-area">
@@ -83,6 +83,7 @@ import type { PropType } from 'vue';
 import type { BoardItemProps, IconSet } from '@/data-display/board-item/type';
 import PTooltip from '@/data-display/tooltips/PTooltip.vue';
 import PI from '@/foundation/icons/PI.vue';
+import { useSelect } from '@/hooks';
 import PIconButton from '@/inputs/buttons/icon-button/PIconButton.vue';
 import PSelectDropdown from '@/inputs/dropdown/select-dropdown/PSelectDropdown.vue';
 
@@ -91,13 +92,17 @@ export default defineComponent<BoardItemProps>({
     components: {
         PTooltip, PIconButton, PSelectDropdown, PI,
     },
+    model: {
+        prop: 'selected',
+        event: 'change',
+    },
     props: {
         leftIcon: {
             type: String,
             default: undefined,
         },
         selected: {
-            type: Boolean,
+            type: String,
             default: undefined,
         },
         rounded: {
@@ -108,14 +113,25 @@ export default defineComponent<BoardItemProps>({
             type: Array as PropType<IconSet[]>,
             default: () => [],
         },
+        value: {
+            type: String,
+            default: undefined,
+        },
     },
     setup(props) {
         const state = reactive({
             iconSetList: computed(() => props.iconButtonSets ?? []),
         });
 
+        const {
+            isSelected,
+        } = useSelect({
+            selected: computed(() => props.selected),
+            value: computed(() => props.value),
+        });
 
         return {
+            isSelected,
             ...toRefs(state),
         };
     },

--- a/src/data-display/board-item/type.ts
+++ b/src/data-display/board-item/type.ts
@@ -4,7 +4,8 @@ export interface BoardItemProps {
     rounded?: boolean;
     leftIcon?: string;
     iconButtonSets?: IconSet[];
-    selected?: boolean;
+    selected?: string;
+    value?: string;
 }
 
 export type ButtonEventHandler = (...args: any[] | any) => Promise<void> | void;

--- a/src/data-display/board/PBoard.vue
+++ b/src/data-display/board/PBoard.vue
@@ -4,17 +4,18 @@
          :style="styleVariableByOptions"
     >
         <template v-for="(board, index) in boardList">
-            <p-board-item :key="`board-${index}`"
+            <p-board-item :key="`board-${board.name}-${index}`"
                           class="p-board-item"
                           :class="{
                               'first-list-item': index === 0,
                               'last-list-item': index === boardList.length - 1,
                               'selectable': selectable
                           }"
+                          :value="board.name"
                           :left-icon="board.leftIcon"
                           :icon-button-sets="board.iconButtonSets"
                           :rounded="board.rounded"
-                          :selected="selected === index"
+                          :selected.sync="selectedItem"
                           @click.stop="handleClickBoardItem(board, index)"
             >
                 <template #left-content>
@@ -76,6 +77,10 @@ export default defineComponent<BoardProps>({
             type: Boolean,
             default: false,
         },
+        selectedItem: {
+            type: String,
+            default: undefined,
+        },
     },
     setup(props, { emit }: SetupContext) {
         const state = reactive({
@@ -90,12 +95,10 @@ export default defineComponent<BoardProps>({
                 }
                 return styles;
             }),
-            selected: undefined as undefined|number,
         });
 
 
         const handleClickBoardItem = (item: BoardSet, index: number) => {
-            if (props.selectable) state.selected = index;
             emit('item-click', item, index);
         };
 

--- a/src/data-display/board/type.ts
+++ b/src/data-display/board/type.ts
@@ -17,6 +17,7 @@ export interface BoardProps {
     boardSets: BoardItemProps[];
     pageLimit?: number;
     selectable?: boolean;
+    selectedItem?: string;
 }
 
 export interface BoardSet extends BoardItemProps {

--- a/src/data-display/label/PLabel.stories.mdx
+++ b/src/data-display/label/PLabel.stories.mdx
@@ -3,7 +3,8 @@ import {i18n} from '@/translations';
 
 import PLabel from '@/data-display/label/PLabel';
 
-import { getLabelArgTypes } from '@/data-display/label/story-helper'; import {computed, reactive, toRefs} from "vue";
+import { getLabelArgTypes } from '@/data-display/label/story-helper';
+import {computed, reactive, toRefs} from "vue";
 
 <Meta title='Data Display/Label' parameters={{
     design: {
@@ -85,19 +86,42 @@ export const Template = (args, {argTypes}) => ({
         {{
             components: { PLabel },
             template: `
-<div class="h-full w-full overflow p-8">
-<div class="flex items-center">
-    <span>Default : &nbsp;</span>
-    <p-label text="Default"/>
-</div>
+                <div class="h-full w-full overflow p-8">
+                    <div class="flex items-center">
+                        <span>Clickable : &nbsp;</span>
+                        <p-label text="Click me" @item-click="handleItemClick" clickable/>
+                        <h1 v-show="state.showEl">Hi~~ You clicked me~~</h1>
+                    </div>
+                </div>
+            `,
+            setup() {
+                const state = reactive({ showEl: false });
+                const handleItemClick = () => { state.showEl = !state.showEl };
+                return { state, handleItemClick }
+            }
+        }}
+    </Story>
+</Canvas>
+
 <br/>
-<div class="flex items-center">
-    <span>Clickable : &nbsp;</span>
-    <p-label text="Click me" clickable/>
-    <p-label text="Mouse hover" clickable/>
-</div>
-</div>
-`
+<br/>
+
+## ClickStop
+
+<br/>
+
+<Canvas>
+    <Story name="ClickStop">
+        {{
+            components: { PLabel },
+            template: `
+                <div class="h-full w-full overflow p-8">
+                    <h1>ClickStop prop for event.stopPropagation()</h1>
+                    <br />
+                    <p-label text="I am not clickable" :click-stop="false" />
+                </div>
+            `,
+            setup() {}
         }}
     </Story>
 </Canvas>

--- a/src/data-display/label/PLabel.vue
+++ b/src/data-display/label/PLabel.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="p-label"
          :class="{ clickable, 'icon-label': leftIcon }"
-         @click.stop="handleClickLabel"
+         @click="handleClickLabel"
     >
         <span class="label-content">
             <slot name="label-content">
@@ -39,6 +39,7 @@ interface LabelProps {
     leftIcon?: string;
     text?: string;
     clickable?: boolean;
+    clickStop?: boolean;
     deletable?: boolean;
     active?: boolean;
 }
@@ -61,6 +62,10 @@ export default defineComponent<LabelProps>({
             type: Boolean,
             default: false,
         },
+        clickStop: {
+            type: Boolean,
+            default: true,
+        },
         deletable: {
             type: Boolean,
             default: false,
@@ -71,7 +76,8 @@ export default defineComponent<LabelProps>({
         },
     },
     setup(props, { emit }: SetupContext) {
-        const handleClickLabel = () => {
+        const handleClickLabel = (e: Event) => {
+            if (props.clickStop) e.stopPropagation();
             if (!props.clickable) return;
             emit('item-click');
         };


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [x] Tested with console(if usages are changed) 

### Description

1. Apply useSelect on PBoard. It needs for multiple board is used in one page.
2. Add `ClickStop` prop for PLabel. When PLabel is only for display, PLabel should inherit parent's event.

### Things to Talk About
