### PR TITLE
fix: add 'I18nConnector' for using i18n in console

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,7 +17,7 @@ import { fontUrls, webFonts } from '@/styles/web-fonts.cjs';
 import VTooltip from 'v-tooltip';
 
 import SpaceOneTheme from './CloudforetTheme';
-import {i18n} from '@/translations'
+import {i18n, I18nConnector} from '@/translations'
 import { applyAmchartsGlobalSettings } from '@/plugins/amcharts';
 import screens from "@/styles/screens.cjs";
 
@@ -36,6 +36,8 @@ applyAmchartsGlobalSettings()
 Vue.prototype.toJSON = function () {
     return this;
 };
+
+I18nConnector.i18n = i18n;
 
 webFontLoader.load({
     google: {

--- a/src/feedbacks/loading/data-loader/PDataLoader.vue
+++ b/src/feedbacks/loading/data-loader/PDataLoader.vue
@@ -63,7 +63,6 @@ import PSkeleton from '@/feedbacks/loading/skeleton/PSkeleton.vue';
 import PSpinner from '@/feedbacks/loading/spinner/PSpinner.vue';
 import type { SpinnerSize } from '@/feedbacks/loading/spinner/type';
 import { SPINNER_SIZE } from '@/feedbacks/loading/spinner/type';
-import { i18n } from '@/translations';
 import { getColor } from '@/utils/helpers';
 
 interface Props {
@@ -81,7 +80,6 @@ interface Props {
 export default defineComponent<Props>({
     name: 'PDataLoader',
     components: { PSpinner, PSkeleton },
-    i18n,
     props: {
         loading: {
             type: Boolean,

--- a/src/inputs/datetime-picker/PDatetimePicker.vue
+++ b/src/inputs/datetime-picker/PDatetimePicker.vue
@@ -27,7 +27,7 @@
 import {
     computed, getCurrentInstance, reactive, toRefs, watch,
 } from 'vue';
-import type { Vue } from 'vue/types/vue';
+import type Vue from 'vue';
 
 import dayjs from 'dayjs';
 import tz from 'dayjs/plugin/timezone';
@@ -39,12 +39,13 @@ import monthSelectPlugin from 'flatpickr/dist/plugins/monthSelect';
 import PI from '@/foundation/icons/PI.vue';
 import type { DatetimePickerProps } from '@/inputs/datetime-picker/type';
 import { DATA_TYPE, SELECT_MODE, STYLE_TYPE } from '@/inputs/datetime-picker/type';
-import { i18n } from '@/translations';
+import { I18nConnector } from '@/translations';
 import { makeOptionalProxy } from '@/utils/composition-helpers';
 
 import { getLocaleFile } from '@/translations/vendors/flatpickr';
 
 import Instance = Flatpickr.Instance;
+
 
 dayjs.extend(utc);
 dayjs.extend(tz);
@@ -64,7 +65,6 @@ type FlatpickrMode = typeof FLATPICKR_MODE[keyof typeof FLATPICKR_MODE];
 
 export default {
     name: 'PDatetimePicker',
-    i18n,
     components: {
         PI,
     },
@@ -132,7 +132,7 @@ export default {
                 }),
             ] : [])),
             localeFile: computed(() => {
-                const localeFile = getLocaleFile(i18n.locale);
+                const localeFile = getLocaleFile(I18nConnector.i18n.locale);
                 if (localeFile) return { ...localeFile, rangeSeparator: ' ~ ' };
                 return { rangeSeparator: ' ~ ' };
             }),

--- a/src/inputs/search/query-search-tags/PQuerySearchTags.vue
+++ b/src/inputs/search/query-search-tags/PQuerySearchTags.vue
@@ -63,13 +63,11 @@ import type {
     QueryTag, QueryTagConverter, QueryTagValidator,
 } from '@/inputs/search/query-search-tags/type';
 import type { QueryItem } from '@/inputs/search/query-search/type';
-import { i18n } from '@/translations';
 
 
 export default defineComponent<QuerySearchTagsProps>({
     name: 'PQuerySearchTags',
     directives: { tooltip: VTooltip },
-    i18n,
     components: {
         PButton, PTag,
     },

--- a/src/inputs/search/search/PSearch.vue
+++ b/src/inputs/search/search/PSearch.vue
@@ -75,7 +75,7 @@ import { useContextMenuFixedStyle, useProxyValue } from '@/hooks';
 import type { MenuItem } from '@/inputs/context-menu/type';
 import type { FilterableDropdownMenuItem } from '@/inputs/dropdown/filterable-dropdown/type';
 import type { SearchProps } from '@/inputs/search/search/type';
-import { i18n } from '@/translations';
+import { I18nConnector } from '@/translations';
 import { makeByPassListeners } from '@/utils/composition-helpers';
 import { getTextHighlightRegex } from '@/utils/helpers';
 
@@ -84,7 +84,6 @@ const PContextMenu = import('@/inputs/context-menu/PContextMenu.vue');
 export default defineComponent<SearchProps>({
     name: 'PSearch',
     components: { PI, PContextMenu },
-    i18n,
     directives: { clickOutside: vOnClickOutside as DirectiveFunction },
     model: {
         prop: 'value',
@@ -159,7 +158,7 @@ export default defineComponent<SearchProps>({
             inputRef: null as null|HTMLElement,
             handlerLoading: false,
             placeholderText: computed<TranslateResult>(() => {
-                if (props.placeholder === undefined) return i18n.t('COMPONENT.SEARCH.PLACEHOLDER');
+                if (props.placeholder === undefined) return I18nConnector.i18n.t('COMPONENT.SEARCH.PLACEHOLDER');
                 return props.placeholder;
             }),
             filteredMenu: [] as MenuItem[],

--- a/src/install.ts
+++ b/src/install.ts
@@ -9,6 +9,8 @@ import Notifications from 'vue-notification';
 import VueRouter from 'vue-router';
 import SvgIcon from 'vue-svgicon';
 
+import { i18n, I18nConnector } from '@/translations';
+
 import { applyAmchartsGlobalSettings } from './plugins/amcharts';
 
 export interface MirinaeOptions {
@@ -16,6 +18,7 @@ export interface MirinaeOptions {
     installVueI18n?: boolean;
     installFragment?: boolean;
     amchartsLicenses?: string[];
+    vueI18n?: VueI18n;
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -49,6 +52,7 @@ export class MirinaeInstaller {
             classPrefix: 'p-i',
         });
         vueConstructor.use(VTooltip, { defaultClass: 'p-tooltip', defaultBoundariesElement: document.body });
+        I18nConnector.i18n = options.vueI18n ?? i18n;
         applyAmchartsGlobalSettings(options?.amchartsLicenses);
     }
 

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -35,3 +35,15 @@ export const i18n = new VueI18n({
     messages,
     silentFallbackWarn: true,
 });
+
+export class I18nConnector {
+    private static _i18n: VueI18n;
+
+    static get i18n() {
+        return I18nConnector._i18n;
+    }
+
+    static set i18n(_i18n: VueI18n) {
+        I18nConnector._i18n = _i18n;
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }) => ({
             output: {
                 globals: {
                     vue: 'Vue',
+                    'vue-i18n': 'vue-i18n',
                 },
             },
         },


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [ ] Not that difficult

### Type of Change
- [ ] New feature
- [X] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [X] Tested with console(if usages are changed) 

### Description
* add 'I18nConnector' which can set i18n for using i18n in console.
* update languages pack.

### Things to Talk About
