### PR TITLE
fix(select-dropdown): delete `primary-button` styleType

### DIFF
--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.stories.mdx
@@ -152,7 +152,6 @@ export const Template = (args, { argTypes }) => ({
                             <th>default</th>
                             <th>icon-button</th>
                             <th>transparent</th>
-                            <th>primary-button</th>
                             <th>secondary-button</th>
                         </tr>
                     </thead>
@@ -193,7 +192,6 @@ export const Template = (args, { argTypes }) => ({
                             <th>default</th>
                             <th>icon-button</th>
                             <th>transparent</th>
-                            <th>primary-button</th>
                             <th>secondary-button</th>
                         </tr>
                     </thead>
@@ -239,7 +237,6 @@ export const Template = (args, { argTypes }) => ({
                             <th>default</th>
                             <th>icon-button</th>
                             <th>transparent</th>
-                            <th>primary-button</th>
                             <th>secondary-button</th>
                         </tr>
                     </thead>

--- a/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
+++ b/src/inputs/dropdown/select-dropdown/PSelectDropdown.vue
@@ -325,11 +325,6 @@ export default defineComponent<SelectDropdownProps>({
             @apply bg-white text-gray-900 border-gray-300;
         }
     }
-    &.primary-button {
-        .dropdown-button {
-            @apply border-none bg-violet-800 text-white;
-        }
-    }
     &.secondary-button {
         .dropdown-button {
             @apply text-violet-800 border-violet-800;
@@ -356,9 +351,6 @@ export default defineComponent<SelectDropdownProps>({
         }
         &.icon-button {
             display: none;
-        }
-        &.primary-button {
-            @mixin read-only-style;
         }
         &.secondary-button {
             @mixin read-only-style;
@@ -396,9 +388,6 @@ export default defineComponent<SelectDropdownProps>({
                 @apply bg-transparent;
             }
         }
-        &.primary-button {
-            @mixin disabled-style-filled-bg;
-        }
         &.secondary-button {
             @mixin disabled-style-filled-bg;
         }
@@ -434,11 +423,6 @@ export default defineComponent<SelectDropdownProps>({
                 @apply text-secondary;
             }
         }
-        &.primary-button {
-            .dropdown-button {
-                @apply text-white bg-blue-600;
-            }
-        }
         &.secondary-button {
             .dropdown-button {
                 @apply border-secondary text-secondary bg-white;
@@ -465,16 +449,6 @@ export default defineComponent<SelectDropdownProps>({
                 @media (hover: hover) {
                     &:not(.active):not(.disabled):hover {
                         @apply text-secondary;
-                        outline: none;
-                    }
-                }
-            }
-        }
-        &.primary-button {
-            .dropdown-button {
-                @media (hover: hover) {
-                    &:not(.active):not(.disabled):hover {
-                        @apply text-white bg-blue-600;
                         outline: none;
                     }
                 }

--- a/src/inputs/dropdown/select-dropdown/type.ts
+++ b/src/inputs/dropdown/select-dropdown/type.ts
@@ -9,7 +9,6 @@ export const SELECT_DROPDOWN_STYLE_TYPE = Object.freeze({
     DEFAULT: 'default',
     ICON_BUTTON: 'icon-button',
     TRANSPARENT: 'transparent',
-    PRIMARY_BUTTON: 'primary-button',
     SECONDARY_BUTTON: 'secondary-button',
 } as const);
 


### PR DESCRIPTION
Signed-off-by: Dahyun Yu <yuda@megazone.com>

### To Reviewers
- [x] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [ ] Feature improvement
  - [ ] These changes require a usage change
- [x] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [ ] Tested with console(if usages are changed) 

### Description
- delete `primary-button` styleType in PSelectDropdown
