### PR TITLE
feat(badge): add `outlineColor` props

### DIFF
--- a/src/data-display/badge/PBadge.stories.mdx
+++ b/src/data-display/badge/PBadge.stories.mdx
@@ -20,6 +20,7 @@ export const Template = (args,{argTypes})=>({
                 :style-type="styleType"
                 :text-color="textColor"
                 :background-color="backgroundColor"
+                :outline-color="outlineColor"
                 :shape="shape"
             >{{$props.defaultSlot}}</p-badge>
         </div>`,

--- a/src/data-display/badge/PBadge.vue
+++ b/src/data-display/badge/PBadge.vue
@@ -40,6 +40,10 @@ export default defineComponent<BadgeProps>({
             type: String,
             default: undefined,
         },
+        outlineColor: {
+            type: String,
+            default: undefined,
+        },
         shape: {
             type: String,
             default: BADGE_SHAPE.ROUND,
@@ -55,10 +59,14 @@ export default defineComponent<BadgeProps>({
             }),
             inlineStyles: computed(() => {
                 // custom case
-                if (props.backgroundColor || props.textColor) {
+                if (props.backgroundColor || props.textColor || props.outlineColor) {
                     const inlineStyle = {} as {[prop: string]: string};
                     if (props.backgroundColor) inlineStyle.backgroundColor = getColor(props.backgroundColor);
                     if (props.textColor) inlineStyle.color = getColor(props.textColor);
+                    if (props.outlineColor) {
+                        inlineStyle.borderColor = getColor(props.outlineColor);
+                        inlineStyle.borderWidth = '1px';
+                    }
                     return inlineStyle;
                 }
                 // static case

--- a/src/data-display/badge/story-helper.ts
+++ b/src/data-display/badge/story-helper.ts
@@ -78,6 +78,24 @@ export const getBadgesArgTypes = (): ArgTypes => ({
             type: 'color',
         },
     },
+    outlineColor: {
+        name: 'outlineColor',
+        type: { name: 'string' },
+        description: 'Outline color of badge.',
+        defaultValue: null,
+        table: {
+            type: {
+                summary: 'string',
+            },
+            category: 'props',
+            defaultValue: {
+                summary: 'null',
+            },
+        },
+        control: {
+            type: 'color',
+        },
+    },
     shape: {
         name: 'shape',
         type: { name: 'string' },

--- a/src/data-display/badge/type.ts
+++ b/src/data-display/badge/type.ts
@@ -52,5 +52,6 @@ export interface BadgeProps {
     styleType: BadgeStyleType;
     textColor?: string;
     backgroundColor?: string;
+    outlineColor?: string;
     shape: BadgeShape;
 }


### PR DESCRIPTION
Signed-off-by: Dahyun Yu <yuda@megazone.com>

### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [x] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [ ] Tested with console(if usages are changed) 

### Description
- add `outlineColor` props of `PBadge`
![스크린샷 2023-02-13 오후 3 57 10](https://user-images.githubusercontent.com/18563857/218393442-61e295dc-c4a7-427e-88e7-74420e1ac679.png)
