### PR TITLE
fix(tag): update tag value style for clear cognition

### DIFF
--- a/src/data-display/tags/PTag.vue
+++ b/src/data-display/tags/PTag.vue
@@ -18,7 +18,9 @@
                 <span v-if="keyItem"
                       class="key"
                 ><slot name="key">{{ keyItem.label || keyItem.name }}:</slot></span>
-                <span v-if="valueItem"><slot name="value">{{ valueItem.label || valueItem.name }}</slot></span>
+                <span v-if="valueItem"
+                      class="value"
+                ><slot name="value">{{ valueItem.label || valueItem.name }}</slot></span>
             </slot>
         </span>
         <p-i v-if="deletable"
@@ -154,6 +156,10 @@ export default defineComponent<Props>({
     .key {
         font-weight: bold;
         margin-right: 0.25rem;
+    }
+    .value {
+        white-space: pre-wrap;
+        word-break: break-all;
     }
 }
 </style>

--- a/src/inputs/search/query-search-tags/PQuerySearchTags.vue
+++ b/src/inputs/search/query-search-tags/PQuerySearchTags.vue
@@ -198,7 +198,7 @@ export default defineComponent<QuerySearchTagsProps>({
                         margin-right: 0.125rem;
                     }
                     .value-label {
-                        white-space: normal;
+                        white-space: pre-wrap;
                         word-break: break-all;
                     }
                 }


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [x] Not that difficult

### Type of Change
- [ ] New feature
- [x] Bug fixes
- [x] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [ ] Updated Storybook documents for component
- [ ] Wrote test codes for composable, utils and etc.
- [x] Tested with console(if usages are changed) 

### Description

**Purpose**
In case of tag's value has white space in both side text or has two or more white spaces in middle of text, 
white space is not showing.
That case makes it difficult to figure out error case caused by white space.

- `white-space: normal` => `white-space: pre-wrap`

