### PR TITLE
fix(board-item): add styles to board-item and board

### DIFF
--- a/src/data-display/board-item/PBoardItem.stories.mdx
+++ b/src/data-display/board-item/PBoardItem.stories.mdx
@@ -44,6 +44,7 @@ export const Template = (args, {argTypes}) => ({
 });
 
 # Board Item
+The style of `board-item` may be different depending on the `board` component Style Type. For example, border-radius, box-shadow, etc.
 <br/>
 <br/>
 
@@ -164,7 +165,7 @@ and when you want a custom ui, use the `left-content` slot to replace it.<br/>
                 </div>
             `,
             setup() {
-                const state = reactive({ selected: false });
+                const state = reactive({ selected: undefined });
                 const handleSelect = (e) => {
                     state.selected = !state.selected
                 };
@@ -235,19 +236,19 @@ Custom content injected into the `custom-right-overlay-content` slot is not repl
             i18n,
             components: { PBoardItem, PTextButton },
             template: `
-    <div class="h-full w-full overflow p-8">
-        <p-board-item>
-            <template #content>
-                <strong>Custom Right Overlay Content - Preview </strong>
-                <p>Hover your mouse over here</p>
-            </template>
-            <template #custom-right-content>
-                <p-text-button icon-right="ic_external-link">Preview</p-text-button>
-            </template>
-        </p-board-item>
-        </p-board-item>
-    </div>
-    `,
+                <div class="h-full w-full overflow p-8">
+                    <p-board-item>
+                        <template #content>
+                            <strong>Custom Right Overlay Content - Preview </strong>
+                            <p>Hover your mouse over here</p>
+                        </template>
+                        <template #custom-right-content>
+                            <p-text-button icon-right="ic_external-link">Preview</p-text-button>
+                        </template>
+                    </p-board-item>
+                    </p-board-item>
+                </div>
+                `,
             setup() {
                 return {}
             }

--- a/src/data-display/board-item/PBoardItem.vue
+++ b/src/data-display/board-item/PBoardItem.vue
@@ -148,14 +148,23 @@ export default defineComponent<BoardItemProps>({
     min-height: 4rem;
     box-sizing: border-box;
     &.rounded {
-        @apply rounded-md;
+        @apply rounded-lg;
     }
     &.selectable {
         cursor: pointer;
     }
     &.selected {
-        @apply border-blue-600 text-blue-600;
-        border-bottom-width: 1px !important;
+        @apply bg-blue-200 relative;
+
+        &::before {
+            @apply absolute border-blue-600;
+            width: calc(100% + 0.125rem);
+            height: calc(100% + 0.125rem);
+            left: -1px;
+            border-width: 0.125rem !important;
+            border-radius: inherit;
+            content: '';
+        }
     }
 
     &:hover {
@@ -169,12 +178,12 @@ export default defineComponent<BoardItemProps>({
             line-height: normal;
         }
         .right-overlay-wrapper {
-            @apply h-full flex items-center bg-blue-100 absolute;
+            @apply flex items-center bg-blue-100 absolute;
+            top: 1rem;
             right: 1rem;
 
             .overlay-contents {
                 @apply h-full w-full flex bg-blue-100;
-                padding: 1rem 0 1rem;
 
                 .overlay-icon-button {
                     height: 2rem;

--- a/src/data-display/board/PBoard.vue
+++ b/src/data-display/board/PBoard.vue
@@ -122,10 +122,10 @@ export default defineComponent<BoardProps>({
         @apply border-b-0;
     }
     .first-list-item {
-        @apply rounded-t-md;
+        @apply rounded-t-lg;
     }
     .last-list-item {
-        @apply rounded-b-md border-b;
+        @apply rounded-b-lg border-b;
     }
 }
 .cards-style {
@@ -135,7 +135,8 @@ export default defineComponent<BoardProps>({
     gap: 0.5rem;
     grid-template-columns: repeat(var(--columns), minmax(0, 1fr));
     .p-board-item {
-        @apply rounded-md;
+        @apply rounded-lg;
+        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.06);
     }
 
     @screen tablet {


### PR DESCRIPTION
### To Reviewers
- [ ] Skipping review is not a problem (```style```, ```chore``` ONLY)
- [X] Not that difficult

### Type of Change
- [ ] New feature
- [ ] Bug fixes
- [X] Feature improvement
  - [ ] These changes require a usage change
- [ ] Others (performance improvement, refactoring, CI/CD, etc.)


### Checklist
- [X] Updated Storybook documents for component
- [X] Wrote test codes for composable, utils and etc.
- [X] Tested with console(if usages are changed) 

### Description
* Fix border and background-color of selected `<p-border-item/>`
* Add box-shadow and border-radius to `<p-border/>`

* [board-item & board Component Figma](https://www.figma.com/file/IS6P8y1Wn2nfBC4jGlSiya/Components?node-id=7449%3A396920&t=u9hk1aHcxZsNfPE2-1)
### Things to Talk About
